### PR TITLE
Pre-commit Optimisation

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,10 @@
+[settings]
+profile = black
+line_length = 88
+remove_redundant_aliases = true
+group_by_package = true
+combine_star = true
+lines_after_imports = 2
+skip_gitignore = true
+skip = skills,examples
+filter_files = true

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,6 @@
 [settings]
 profile = black
+sort_order = natural
 line_length = 88
 remove_redundant_aliases = true
 group_by_package = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: isort
         name: isort (python)
         exclude: ^skills/
-        args: ["--profile", "black", "--filter-files"]
+        args: ["--profile", "black", "--line-length", "88", "--filter-files"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,19 +15,18 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: ^skills/
+        exclude: ^(skills/|examples/)
       - id: end-of-file-fixer
-        exclude: ^skills/
+        exclude: ^(skills/|examples/)
   - repo: https://github.com/pycqa/isort
     rev: 9.0.0a3
     hooks:
       - id: isort
         name: isort (python)
-        exclude: ^skills/
-        args: ["--profile", "black", "--line-length", "88", "--filter-files"]
+        exclude: ^(skills/|examples/)
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or: [markdown]
-        exclude: ^skills/
+        exclude: ^(skills/|examples/)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-05T09:39:38Z",
+  "generated_at": "2026-05-07T14:15:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -122,7 +122,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,13 @@ path = "src/mellea_skills_compiler/__init__.py"
 [project.scripts]
 mellea-skills = "mellea_skills_compiler.cli:app"
 
-[tool.isort]
-profile = "black"
-line_length = 88
-remove_redundant_aliases = true
-group_by_package = true
-combine_star = true
-lines_after_imports = 2
+# [tool.isort]
+# profile = "black"
+# line_length = 88
+# remove_redundant_aliases = true
+# group_by_package = true
+# combine_star = true
+# lines_after_imports = 2
 
 [tool.pdm.build]
 package-dir = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,5 @@ path = "src/mellea_skills_compiler/__init__.py"
 [project.scripts]
 mellea-skills = "mellea_skills_compiler.cli:app"
 
-# [tool.isort]
-# profile = "black"
-# line_length = 88
-# remove_redundant_aliases = true
-# group_by_package = true
-# combine_star = true
-# lines_after_imports = 2
-
 [tool.pdm.build]
 package-dir = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ secrets = ["detect-secrets @ git+https://github.com/ibm/detect-secrets.git@maste
 source = "file"
 path = "src/mellea_skills_compiler/__init__.py"
 
-
 [project.scripts]
 mellea-skills = "mellea_skills_compiler.cli:app"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "ai-atlas-nexus[ollama]",
     "rich",
     "typer",
-    "isort",
     "anthropic",
     "packaging"
 ]


### PR DESCRIPTION
Hi @ingelise 
I removed the isort args from both `pyproject.toml` and `.pre-commit-config.yaml`, and created a central isort recommended `.isort.cfg` configuration file.

The `.isort.cfg` file is supported by most IDEs - **vscode**, **pycharm** as well as **pyproject.toml**, **pre-commit** and the **isort** cli.

You can check the args inside `.isort.cfg` are respected by running following command:

```
isort . --show-config
```

**NOTE:** **isort** only works for the import statements. For code-formatting we need a similar **black** hook in pre-commit file, so that all commits follow the same code styles. 

`isort --profile black` does not call the black formatter nor does it format your entire code. Instead, it tells isort to configure its import sorting rules to match Black's expected style (e.g., using parentheses for multi-line imports, 88 character line length, specific spacing).