### PR TITLE
docs: ship dialect specifications referenced by mellea-fy commands    

### DIFF
--- a/.claude/commands/mellea-fy-inventory.md
+++ b/.claude/commands/mellea-fy-inventory.md
@@ -10,7 +10,7 @@ Step 1a reads files from the source based on the detected runtime's dialect. Ste
 
 ## Step 1a: File Inventory
 
-Read source files per the runtime's dialect. The dialect doc at `melleafy-handoff/plans/dialects/<runtime>.md` defines exactly which files to read and their roles.
+Read source files per the runtime's dialect. The dialect doc at `docs/dialects/<runtime>.md` defines exactly which files to read and their roles.
 
 | Runtime             | Primary files                                                          | Roles                                                                      |
 | ------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------- |

--- a/.claude/commands/mellea-fy-map.md
+++ b/.claude/commands/mellea-fy-map.md
@@ -94,7 +94,7 @@ Record `final_target_file: "pending_step_2.5"` in the mapping entry until Step 2
 
 ## Dialect-specific overrides
 
-The dialect mapping table in `melleafy-handoff/plans/dialects/<runtime>.md` takes precedence over the general table above.
+The dialect mapping table in `docs/dialects/<runtime>.md` takes precedence over the general table above.
 
 Precedence (highest first):
 

--- a/docs/dialects/README.md
+++ b/docs/dialects/README.md
@@ -1,0 +1,35 @@
+# Mellea-fy Dialect Documentation
+
+Per-runtime mapping rules consumed by Steps 0, 1, and 2 of the `mellea-fy` workflow:
+
+- **Step 0** (classification): the source-runtime axis 4 selects which dialect applies.
+- **Steps 1a/1b** (inventory): the dialect doc lists the files to read and the roles they play.
+- **Step 2** (mapping): the dialect doc supplies overrides that take precedence over the general primitive-mapping table.
+
+## Naming convention
+
+Each file is `<runtime>.md` where `<runtime>` matches the value of `classification.json:source_runtime` (and the entries in the Step 0 axis-4 table in `mellea-fy-classify.md`).
+
+## Supported runtimes (this directory)
+
+| Runtime | File | Status |
+|---|---|---|
+| `agent_skills_std` | `agent-skills-std.md` | Mature |
+| `claude_code` | `claude-code.md` | Mature |
+| `openclaw` | `openclaw.md` | Mature |
+| `crewai` | `crewai.md` | Mature |
+| `langgraph` | `langgraph.md` | Mature |
+| `letta` | `letta.md` | Mature |
+| `hybrid` | `hybrid.md` | Mature (rules for ambiguous classifications) |
+
+## Stubbed runtimes (not yet shipped here)
+
+The following are recognised by the Step 0 classifier but do not yet have shipping dialect docs in this directory; the compiler falls back to the generic inventory and mapping rules for them, with a warning surfaced in the run's `mapping_report.md`:
+
+- `autogen`
+- `openai_agents_sdk`
+- `smolagents`
+
+## What if my runtime is not listed at all?
+
+The Step 0 classifier returns `unknown`. The compiler proceeds with the generic inventory pass and the general mapping table; the package will be generated but without runtime-specific knowledge. Open a discussion if your runtime is widely used and you want a dedicated dialect doc.

--- a/docs/dialects/agent-skills-std.md
+++ b/docs/dialects/agent-skills-std.md
@@ -1,0 +1,355 @@
+# Agent Skills std Dialect
+
+**Version**: 1.0.0
+**Status**: Fifth dialect doc. The open-standard form — deliberately minimal and runtime-neutral. Shares its frontmatter core with Claude Code; everything distinctive about it is what it doesn't have.
+
+**Prerequisite reading**: `spec.md` R1 (detection), R22 (dialect mapping contract), R21 (modality); `plans/dialects/openclaw.md` (reference template); `plans/dialects/claude-code.md` (the superset — Agent Skills std's extensions live there); `plans/generated-package-shape.md` (output shape).
+
+---
+
+## What this document does
+
+Describes the rules melleafy applies when processing an **Agent Skills std** source spec. Agent Skills std is the open specification at agentskills.io — a minimal, runtime-neutral format for packaging agent instructions. It predates and is independent of any specific runtime. Claude Code, Codex, Cursor, and others layer their own invocation conventions on top.
+
+What makes Agent Skills std distinctive is not its content but its **restraint**: it specifies packaging and progressive disclosure, and deliberately punts invocation modality, tool execution, and runtime concerns to the host.
+
+Key Agent Skills std concepts readers should have in mind:
+
+- **Progressive disclosure**: metadata (~100 tokens), instructions (<5000 tokens), resources loaded as needed.
+- **Six-field frontmatter**: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` — and nothing else under the open standard.
+- **The Anthropic `quick_validate.py` validator**: rejects unknown keys. Strict allow-list.
+- **Three conventional directories**: `scripts/`, `references/` (or `reference/`), `assets/`.
+- **No runtime fields**: no `.claude/`, no `settings.json`, no `langgraph.json`, no `openclaw.json`. If those exist, the spec is a superset runtime, not Agent Skills std.
+
+**Relationship to Claude Code.** Claude Code is a strict superset of Agent Skills std — every Agent Skills field works in Claude Code, plus the roughly dozen extensions documented in `plans/dialects/claude-code.md` §3. This doc is **not** a subset-by-reference; it's written to stand alone so an Agent Skills implementation doesn't require a Claude Code read. Where behavior is identical to Claude Code, this doc restates it briefly; where it diverges, the divergence is explicit.
+
+---
+
+## 1. Detection signals
+
+Agent Skills std detection is fundamentally the **absence** of runtime-specific signals. A `SKILL.md` with only standard frontmatter fields and none of the runtime extensions is Agent Skills std.
+
+| Signal | Strength | Notes |
+|---|---|---|
+| `SKILL.md` file as the primary spec | strong | The defining artefact |
+| Frontmatter `name` matching regex `^[a-z0-9]+(-[a-z0-9]+)*$` | strong | Required-by-standard |
+| Frontmatter `description` present | strong | Required-by-standard |
+| Frontmatter fields limited to `{name, description, license, compatibility, metadata, allowed-tools, when_to_use}` | strong | No fields outside the std allow-list (plus the one known extension) |
+| `scripts/`, `references/` / `reference/`, `assets/` directories sibling to `SKILL.md` | medium | Conventional layout |
+| No `.claude/` directory at any level | medium | Rules out Claude Code |
+| No `.mcp.json` at any level | medium | Rules out Claude Code and runtime-layered |
+| No runtime-specific files (`langgraph.json`, `openclaw.json`, `.af`, `crew.py`, etc.) | medium | Rules out every other v1-supported runtime |
+
+**Disambiguating from Claude Code.** This is the most common disambiguation needed. If the *only* matching signals are standard frontmatter plus conventional directories, and no Claude Code extension field appears, classify as Agent Skills std. **Presence of any Claude Code extension field or `.claude/` location elevates to Claude Code** (per `plans/dialects/claude-code.md` §1).
+
+**Precedence note.** R1 tiebreak order puts Agent Skills std **first** — it wins strict ties. The rationale: Agent Skills std is the open, minimal format; when signals are balanced, treating a spec as Agent Skills std produces the more portable output.
+
+**Hybrid threshold.** Agent Skills std rarely hybridises with another runtime because its defining characteristic is absence of runtime-specific signals. If Agent Skills std signals appear alongside (say) Claude Code signals, Claude Code wins outright on signal count — no Hybrid.
+
+---
+
+## 2. File inventory rules (Step 1a)
+
+The workspace is the directory containing `SKILL.md`. Agent Skills std's workspace is smaller and more predictable than Claude Code's — no upward-walking CLAUDE.md, no `.claude/` directory.
+
+### 2a. Primary spec
+
+| File | Role | Inventory action |
+|---|---|---|
+| `SKILL.md` in the workspace root | C1 Identity + C2 Operating rules + metadata | Parse frontmatter; body decomposed per Step 1b |
+
+The body is subject to the progressive-disclosure size guidance: ≤5,000 tokens, ≤500 lines. Specs exceeding either limit are inventoried in full (same policy as OpenClaw's oversize files) but flagged in the inventory report.
+
+### 2b. Conventional directories
+
+| Directory | Role | Inventory action |
+|---|---|---|
+| `scripts/` | C6 Tools (executable content) or TOOL_INPUT (data producers) | Each file becomes a candidate C6 element; classification depends on content |
+| `references/` or `reference/` | C1 Identity / C2 Operating rules / C5 Long-term memory | Each file's content becomes elements; the tag depends on content |
+| `assets/` | External data dependencies | Each file recorded as a TOOL_INPUT or referenced data source; v1 does not inline contents |
+
+**Rule 2b-1**: the `references/` vs `reference/` naming disagreement is real — the open standard says plural (`references/`); `anthropics/skills` validator uses plural; `mcp-builder` and some other projects use singular. Step 1a checks for **both**; whichever exists is inventoried. If both exist simultaneously (rare), both are inventoried and the anomaly is flagged in the report.
+
+**Rule 2b-2**: `assets/` files are treated as data referenced by the spec, not as spec content. They're recorded in the inventory with `role: "external asset"` and their contents are **not** inlined into elements. If the generated package needs access to an asset, the mapping report recommends the user bundle the asset alongside the generated package themselves — v1 melleafy does not copy assets into output.
+
+### 2c. Non-standard but commonly-seen directories
+
+Real Anthropic skills (in `anthropics/skills`) ship directories that aren't part of the open standard:
+
+| Directory | Handling |
+|---|---|
+| `evals/` | Detect; note in report; **do not bundle** into output unless explicitly requested |
+| `eval-viewer/` | Detect; note; do not bundle |
+| `agents/` | Detect; note as possible cross-skill reference; do not inventory contents |
+| `shared/` | Detect; note; contents not inventoried by default |
+
+**Rule 2c-1**: these directories are common in practice but non-portable across Agent Skills implementations (not every host recognises them). Melleafy's conservative default is to detect them and flag their presence without bundling them into the generated package. A user who wants these bundled explicitly can override in Step 2.5 elicitation.
+
+### 2d. Supporting files
+
+| File | Role | Inventory action |
+|---|---|---|
+| `LICENSE.txt` (or similar) | Referenced by `license` frontmatter | Read if present; passed through to generated `LICENSE` file |
+| `README.md` (if present) | Free-form notes | NO_DECOMPOSE unless spec body references it directly |
+| `.env` / `.env.example` | C7 credentials | Parse; one element per var |
+
+**Rule 2d-1**: Agent Skills std has no conventional place for env-var declaration (Claude Code uses `settings.env`; CrewAI uses project `.env` auto-loading). Melleafy's v1 policy: if a `.env.example` exists, inventory it. Otherwise, credential dependencies (C7) are inferred from spec body content (API names, auth patterns).
+
+### 2e. No upward walking, no multi-location skill precedence
+
+Unlike Claude Code, Agent Skills std has **no upward-walking CLAUDE.md hierarchy** and **no precedence-tiered skill locations** (no managed/user/project/plugin tiers). The workspace is literally "the SKILL.md's directory plus its conventional subdirectories."
+
+**Rule 2e-1**: if an ancestor directory has a `CLAUDE.md`, it's ignored — Agent Skills std specs are not expected to have CLAUDE.md context. Detection is: if a CLAUDE.md *is* found in an ancestor, Step 0 should probably have classified as Claude Code, not Agent Skills std. This is a cross-check for detection quality.
+
+### 2f. Missing files
+
+Absence rules:
+
+- `SKILL.md` absent: halt — Agent Skills std specs *must* have a SKILL.md. If detection said Agent Skills std but no SKILL.md exists, classification was wrong.
+- `scripts/` / `references/` / `assets/` absent: normal; these are optional.
+- `LICENSE.txt` absent but `license:` field references it: warn.
+- `.env.example` absent: normal; credentials inferred from body.
+
+---
+
+## 3. Frontmatter rules — the strict allow-list
+
+Agent Skills std's frontmatter is strictly validated. The Anthropic `quick_validate.py` rejects unknown keys. Melleafy enforces the same allow-list when the source is Agent Skills std.
+
+### 3a. Authoritative field set
+
+Six fields, per the open standard:
+
+| Field | Required | Constraint |
+|---|---|---|
+| `name` | yes | 1–64 chars, regex `^[a-z0-9]+(-[a-z0-9]+)*$`, must match parent directory name |
+| `description` | yes | 1–1024 chars; describes *what* + *when* |
+| `license` | no | Free-form string or reference to a bundled `LICENSE.txt` |
+| `compatibility` | no | ≤500 chars; free text for system packages, network, host product |
+| `metadata` | no | map of string→string; convention stores `version`, `author` here |
+| `allowed-tools` | no | **experimental**; space-separated string like `Bash(git:*) Bash(jq:*) Read` |
+
+**Rule 3a-1**: `name` length quietly changed from 40 to 64 chars in PR #350. Older validators may reject names 41–64 chars long; melleafy accepts the full 1–64 range on input and surfaces length in the inventory report.
+
+**Rule 3a-2**: `name` must equal the parent directory name — this is an implicit requirement across Agent Skills implementations. Step 1a cross-checks and warns if they differ.
+
+**Rule 3a-3**: `allowed-tools` is formally experimental under the open standard. Melleafy parses it like any other C6 source signal but notes in the mapping report that the field is experimental — specs depending on it may not be portable to future Agent Skills versions.
+
+### 3b. The `when_to_use` extension
+
+`when_to_use` appears in real-world Agent Skills specs but **is not in the validator allow-list**. It's the most common extension. Melleafy's handling:
+
+- **Parse it if present** — the content is spec-relevant
+- **Append to `description` for internal use** — treat it as supplementary description content
+- **Never emit it on output targeting Agent Skills std** — if melleafy ever regenerates a SKILL.md frontmatter (rare; not a v1 feature), it must not include `when_to_use` because `quick_validate.py` would reject the output
+
+**Rule 3b-1**: unknown frontmatter fields *other than* `when_to_use` are errors under the standard. Melleafy surfaces them in the inventory report but does not halt — the spec is still processable, just not standard-compliant.
+
+### 3c. Frontmatter parsing and validation
+
+Parsed with `yaml.safe_load`. Same machinery as Claude Code (`plans/dialects/claude-code.md` §3d). Post-parse, melleafy validates:
+
+- All required fields present
+- All present fields are in the allow-list (plus `when_to_use`)
+- Constraint checks per §3a
+
+Validation failures become warnings in the inventory report, not halts. Constitution Article 1 requires generation to succeed for any parseable input.
+
+---
+
+## 4. Dialect mapping table
+
+| Source signal | Category | Default disposition | Generation target |
+|---|---|---|---|
+| `name` frontmatter field | — | `bundle` | `pyproject.toml:name`, `README.md` title, `__init__.py:__agent_name__` |
+| `description` frontmatter field | C1 | `bundle` | `config.AGENT_DESCRIPTION` |
+| `when_to_use` frontmatter field | C1 | `bundle` | Appended to `config.AGENT_DESCRIPTION` |
+| `license` frontmatter field | — | `bundle` | `pyproject.toml:license`; `LICENSE` file copied if `LICENSE.txt` exists |
+| `compatibility` frontmatter field | C8 | `bundle` | `config.COMPATIBILITY_NOTE`; included in README; informational only |
+| `metadata.version` | — | `bundle` | `pyproject.toml:version` |
+| `metadata.author` | — | `bundle` | `pyproject.toml:authors` |
+| `metadata.*` (other keys) | — | `bundle` | `config.METADATA` dict |
+| `allowed-tools` entries (generic) | C6 | Varies per entry type | See per-pattern rules below |
+| `allowed-tools` `Bash(pattern)` | C6 | `stub` | `constrained_slots.py:run_bash`; SETUP.md §8 |
+| `allowed-tools` `Read(path-glob)` / `Write(...)` / `Edit(...)` | C6 | `stub` | Filesystem I/O deferred to host |
+| `allowed-tools` `WebFetch(domain:*.example.com)` | C6 | `real_impl` | `tools.py:web_fetch` |
+| `SKILL.md` body — main content | Varies (C1/C2/C6 mixed) | Decomposed per Step 1b | Various |
+| File under `scripts/` | C6 | `real_impl` if Python/shell concrete | `tools.py:<script_name>` |
+| File under `scripts/` (non-executable language) | C6 | `stub` | `constrained_slots.py`; SETUP.md §8 |
+| File under `references/` or `reference/` — prose content | C1 / C2 | `bundle` | Inventoried as additional elements; mapped to `config.*` or `requirements.py` |
+| File under `references/` or `reference/` — structured data | C5 | `load_from_disk` | `loader.py:load_<n>`; asset bundled alongside |
+| File under `assets/` | — | `external_input` | Asset recorded in mapping report; user bundles alongside generated package |
+| `LICENSE.txt` | — | `bundle` | Copied to output as `LICENSE` |
+| `.env.example` entries | C7 | `external_input` | `.env.example` in generated package |
+| `evals/` directory present | — | *(not reproduced)* | Noted in mapping report |
+| `agents/` directory present | — | *(deferred)* | Noted as possible cross-skill reference |
+| `shared/` directory present | — | *(not reproduced)* | Noted |
+
+**Override semantics.** Default dispositions can be overridden via `--dependencies=ask` or `config:<path>` per the standard R22 contract.
+
+**Rule 4-1**: Agent Skills std has no native C4 (short-term state), C9 (scheduling), or modality-declaring fields. Specs that imply these concerns (e.g., a spec body saying "remember where we left off") are inferred as C4 with `delegate_to_runtime` disposition. The inference is surfaced with `source_of_decision: "inferred"`.
+
+**Rule 4-2**: the mapping is deliberately minimal — Agent Skills std has a small surface. Complexity lives in the SKILL.md body content, which Step 1b decomposes per its standard rules.
+
+---
+
+## 5. Modality signals (Step 0 Axis 5, R21)
+
+**Agent Skills std deliberately declares nothing about invocation modality.** The open standard specifies packaging and progressive disclosure; the host runtime decides how skills are invoked.
+
+**Rule 5-1**: Agent Skills std specs have **no explicit modality signals**. Step 0 Axis 5 Pass 1 (explicit declarations) returns empty. Classification relies entirely on Pass 2 (LLM inference) per `plans/steps/step-0-classification.md` §7b-3.
+
+**Rule 5-2**: inference for Agent Skills std specs typically lands on `synchronous_oneshot` — a skill invoked once, runs to completion, returns a result. This is the default assumption when no other signals suggest otherwise.
+
+**Rule 5-3**: when the spec body describes multi-turn interaction ("the user then provides..."), inference may produce `conversational_session`. When the spec describes streaming output ("produce each section as you finish it"), `streaming` is possible. These are LLM judgments, recorded with confidence scores.
+
+**Rule 5-4**: host-needing modalities (`review_gated`, `scheduled`, `event_triggered`, `heartbeat`, `realtime_media`) are rare outcomes for Agent Skills std specs because nothing in the standard supports them. If the spec body clearly describes scheduling or event triggering, melleafy classifies accordingly but SETUP.md §6/§7 must explicitly note that the source format declares nothing about how these will be wired — the user is picking the host adapter from scratch.
+
+**Generated shape per R21.** The generated package's entry-point shape follows whatever modality was inferred, per §5a–§5e of the shape doc. For the common case (`synchronous_oneshot` with low confidence), the shape is §5a and the mapping report surfaces the uncertainty.
+
+### 5a. Low-confidence modality is normal
+
+Because Agent Skills std has no explicit signals, **Pass 2 LLM confidence is the sole indicator of modality correctness.** Confidence below 0.7 triggers a retry per Step 0 §3b-1; after retry, the result is committed regardless. Unlike other dialects where low modality confidence is anomalous, for Agent Skills std it's expected.
+
+**Rule 5a-1**: when inferred modality confidence is below 0.7 and the spec ships, the mapping report's Classification section includes a prominent note: "Modality inferred from spec body with confidence <0.7>. Agent Skills std declares no modality; review generated `main.py` entry-point shape to confirm it matches intended use."
+
+---
+
+## 6. Quirks and workarounds
+
+### 6a. The `references/` vs `reference/` disagreement
+
+Addressed in §2b rule 2b-1. This is not a quirk of Agent Skills std itself — it's a disagreement between the open-standard spec and real-world implementations. Melleafy handles both.
+
+### 6b. Non-portable real-world extensions
+
+Real Anthropic skills (in `anthropics/skills`) use features not in the open standard:
+
+- `evals/`, `eval-viewer/` directories — test infrastructure
+- `agents/` directory — cross-skill delegation (overlaps with Claude Code subagents)
+- `shared/` directory — shared utilities
+
+These work in Anthropic's tooling but are **not portable** across Agent Skills implementations. Melleafy flags their presence and doesn't bundle them by default — a user wanting to target Anthropic tooling specifically can override.
+
+### 6c. `allowed-tools` is experimental
+
+Marked experimental under the open standard. Future versions may remove it or change its semantics. Melleafy treats it as a C6 source signal (same as other tool declarations) but notes in mapping report that the field is unstable.
+
+### 6d. No upward context walking
+
+Unlike Claude Code, Agent Skills std has no ancestor-directory context. A SKILL.md spec is self-contained relative to its workspace. If the author needs context (e.g., project-wide conventions), it must be inlined into the SKILL.md body or placed in `references/`.
+
+**Rule 6d-1**: melleafy does not read CLAUDE.md or similar ancestor files when processing Agent Skills std. If a spec relied on ancestor context that's not available, the spec was under-specified as Agent Skills std — the user's options are (a) classify as Claude Code instead, or (b) inline the context into the SKILL.md.
+
+### 6e. No invocation contract
+
+Agent Skills std says nothing about how the skill is invoked: no CLI flags, no function signatures, no session model. The host runtime defines all of this. Melleafy's generated package picks an invocation contract (typically `run_pipeline(input: Input) -> Output` via `main.py`) but this is a **melleafy decision, not a source-derived one**. The mapping report notes this explicitly:
+
+> "Agent Skills std declares no invocation contract. The generated package exposes a synchronous function `run_pipeline(input)` and a `main.py` CLI entry point. If the skill was intended for a specific host (Claude Code, Codex, Cursor), the user may need an adapter layer."
+
+### 6f. Progressive disclosure is a runtime concern
+
+The Agent Skills std spec describes progressive disclosure as a **runtime behavior** — the host loads metadata first, instructions second, resources on demand. Melleafy-generated packages have no equivalent mechanism — everything is loaded at import time.
+
+**Rule 6f-1**: specs that explicitly depend on progressive disclosure for token-budget reasons (very rare) won't get the same behavior from melleafy-generated packages. Noted in mapping report but not a common concern.
+
+### 6g. Metadata convention vs spec
+
+`metadata` in frontmatter is a free map of string→string. Convention stores `version` and `author` keys; some implementations add `keywords`, `homepage`, etc. Melleafy's mapping (§4) special-cases `version` and `author` to map to `pyproject.toml` fields; others land in a catch-all `config.METADATA` dict. If a specific implementation's convention emerges that melleafy should special-case, that's a mapping table addition.
+
+### 6h. `compatibility` field semantics
+
+The `compatibility` field is free-text up to 500 chars. Typical content: "Requires Python 3.11+; uses pandas; macOS only." Melleafy does not parse this field structurally — it's copied into `config.COMPATIBILITY_NOTE` verbatim and surfaced in README. The 500-char limit is a soft convention; melleafy warns on oversize but proceeds.
+
+---
+
+## 7. Reference inventory output (illustrative)
+
+For a minimal Agent Skills std spec — a `SKILL.md` with frontmatter, a `scripts/` directory with one Python helper, and a `references/` directory with one prose reference:
+
+### Inventory (abridged)
+
+```json
+{
+  "elements": [
+    {"element_id": "elem_001", "source_file": "SKILL.md", "source_lines": "frontmatter.name", "tag": "CONFIG", "category": "—", "content_summary": "Skill name: ticket-triage"},
+    {"element_id": "elem_002", "source_file": "SKILL.md", "source_lines": "frontmatter.description", "tag": "CONFIG", "category": "C1", "content_summary": "Description: triage customer support tickets"},
+    {"element_id": "elem_003", "source_file": "SKILL.md", "source_lines": "frontmatter.when_to_use", "tag": "CONFIG", "category": "C1", "content_summary": "When to use: whenever a new ticket arrives"},
+    {"element_id": "elem_010", "source_file": "SKILL.md", "source_lines": "15-40", "tag": "ORCHESTRATE", "category": "C2", "content_summary": "Classification-then-routing workflow"},
+    {"element_id": "elem_020", "source_file": "scripts/fetch_priority.py", "source_lines": "py:scripts/fetch_priority.py:1-30", "tag": "TOOL_TEMPLATE", "category": "C6", "content_summary": "Python helper: fetch ticket priority from API"},
+    {"element_id": "elem_030", "source_file": "references/routing-rules.md", "source_lines": "1-50", "tag": "CONFIG", "category": "C2", "content_summary": "Routing rules reference: priority-to-team mapping"}
+  ]
+}
+```
+
+Note `source_lines` formats: `frontmatter.<field>` for frontmatter references, `py:<file>:<range>` for Python files under `scripts/`, line ranges for Markdown. These are shared conventions with other dialects (Claude Code, LangGraph respectively).
+
+### Element mapping (abridged)
+
+```json
+{
+  "mappings": [
+    {"element_id": "elem_001", "target_file": "pyproject.toml", "target_symbol": "name", "primitive": "bundle"},
+    {"element_id": "elem_002", "target_file": "config.py", "target_symbol": "AGENT_DESCRIPTION", "primitive": "bundle"},
+    {"element_id": "elem_003", "target_file": "config.py", "target_symbol": "AGENT_DESCRIPTION", "primitive": "bundle"},
+    {"element_id": "elem_010", "target_file": "pipeline.py", "target_symbol": "run_pipeline", "primitive": "orchestrate"},
+    {"element_id": "elem_020", "target_file": "tools.py", "target_symbol": "fetch_priority", "primitive": "real_impl"},
+    {"element_id": "elem_030", "target_file": "requirements.py", "target_symbol": "OPERATING_REQUIREMENTS", "primitive": "requirement"}
+  ]
+}
+```
+
+### Dialect-specific notes in the mapping report
+
+- A "Modality inference" section noting confidence level and the rationale (since Agent Skills std has no explicit modality).
+- A "Non-portable extensions detected" section listing `evals/`, `agents/`, `shared/` if present.
+- An "Invocation contract" callout (per §6e) noting that Agent Skills std declares no contract; the generated package's shape is a melleafy decision.
+
+---
+
+## 8. Deferred Agent Skills std features (not handled in v1)
+
+- **Cross-skill references via `agents/` directory** — not portable under the open standard; v1 flags but doesn't follow. v2 could offer explicit opt-in.
+- **Progressive disclosure at runtime** (§6f) — v1 generates loaded-at-import packages.
+- **Regenerating SKILL.md frontmatter as output target** — if a v2 feature lets users regenerate Agent Skills std-compliant SKILL.md from a Mellea package, strict adherence to the validator allow-list (no `when_to_use`) becomes important. Not a v1 concern.
+- **Validator version tracking** — the allow-list field count could grow in future standard revisions. v1 targets the 2026-Q1 allow-list; future melleafy versions should track.
+- **Host-specific adapter generation** — a user targeting Codex or Cursor from an Agent Skills std spec would benefit from an adapter layer; v1 produces a generic Mellea package.
+
+---
+
+## 9. Cross-references
+
+- `spec.md` R1, R21, R22 — the contracts this dialect implements
+- `plans/dialects/openclaw.md` — template this dialect adapts
+- `plans/dialects/claude-code.md` — the superset runtime; Claude Code extensions live there
+- `plans/dialects/letta.md` — for comparison of single-file source models
+- `plans/dialects/langgraph.md` — for comparison of code-first source models
+- `plans/generated-package-shape.md` — shape of the generated output
+- `glossary.md` — `dialect`, `disposition`, `interaction modality`
+
+---
+
+## 10. Ratification notes
+
+This dialect doc v1.0.0 was the fifth drafted, selected to validate the "subset-of-another-dialect" pattern — Agent Skills std is strictly contained in Claude Code's feature set, and writing this doc after Claude Code tests whether the subset relationship produces clean, non-duplicative documentation.
+
+**What the template survived unchanged:**
+- All ten sections translated directly without structural adaptation. This is expected — Agent Skills std's surface is a strict subset of what the template already handles.
+- Sections 2, 3, 4, 5 are much shorter than Claude Code's because Agent Skills std has fewer surfaces to enumerate. This is a natural consequence of the source format's restraint.
+
+**The subset pattern — what it means for dialect documentation:**
+- Each dialect doc is **written to stand alone** (no subset-by-reference). A reader implementing Agent Skills std support shouldn't have to read Claude Code's doc first. This costs some duplication of frontmatter rules, but gains independence and local readability.
+- Where Agent Skills std and Claude Code behavior is identical (e.g., `yaml.safe_load` for frontmatter), this doc names the behavior briefly and optionally cross-references Claude Code's §3d for detail. Readers who want only Agent Skills std context don't need to jump.
+- Where Agent Skills std and Claude Code diverge (strict allow-list vs permissive, no upward walking vs CLAUDE.md hierarchy, no invocation contract vs full CLI surface), the divergence is called out explicitly.
+
+**What this tells us about template generality.** Writing a subset dialect took noticeably less effort per section than writing Claude Code or LangGraph (which required new concepts). The template accommodates subsets naturally — there's no pressure to invent new structure just because the content is smaller. Good sign for the remaining three runtime-specific dialects (CrewAI, AutoGen, OpenAI Agents SDK, smolagents — each with a mix of novel concepts and shared Agent-Skills-adjacent ideas).
+
+Open questions:
+
+- **§5 modality as LLM-inference-only** is a correct outcome but leaves users with less-reliable classification than other dialects. Worth considering whether Agent Skills std specs should ship with a mandatory `--modality=<explicit>` flag that users provide when the inference is known to be wrong. v1 default: infer and warn on low confidence. v2: maybe a flag.
+- **§3b `when_to_use` handling** (parse but don't emit on output) matters only if melleafy grows a "regenerate Agent Skills std spec" capability. v1 doesn't do this, so the rule is aspirational. Flagged as a v2 consistency concern.
+- **§2c non-standard directory handling** treats `evals/`, `agents/`, `shared/` as "detect but don't bundle." A user targeting Anthropic's specific Agent Skills tooling may want these bundled. Worth a `--include-nonstandard-dirs` flag; not prioritised for v1.
+- **§6g metadata convention** — if specific implementations develop their own `metadata` conventions (e.g., `metadata.category`, `metadata.tags`), melleafy should grow special cases. For now, the catch-all `config.METADATA` dict is adequate.
+- **Relationship to Claude Code detection in practice** — the most common disambiguation mistake would be classifying a Claude Code spec as Agent Skills std because no `.claude/` directory exists in the specific skill's workspace but an ancestor has one. Step 1a §2e addresses this by not walking upward for Agent Skills std classifications. The cross-check is in Step 0 detection logic: signals are counted per the spec, but ancestor directories don't contribute to Agent Skills std detection.
+- **The 2b-1 `references/`/`reference/` handling** assumes at most one of the two exists. If both exist (extremely rare but possible in a project that refactored), both are inventoried. Worth treating this as a warning in the inventory report.
+- **Progressive disclosure** (§6f) is tangential to melleafy's generation model. Some Agent Skills users may specifically be *relying on* progressive disclosure for token-budget reasons. v1's "load everything at import" doesn't respect this. Flagged as a v2 concern if it ever matters.

--- a/docs/dialects/claude-code.md
+++ b/docs/dialects/claude-code.md
@@ -1,0 +1,501 @@
+# Claude Code Dialect
+
+**Version**: 1.0.0
+**Status**: Third dialect doc. Stress-tests the template against the most feature-rich runtime in the v1 supported set — multiple skill locations with precedence, upward-walking CLAUDE.md, structured settings JSON, nine-plus hook events, subagents, MCP, session-scoped scheduling, plugin manifests.
+
+**Prerequisite reading**: `spec.md` R1 (detection), R22 (dialect mapping contract), R21 (modality); `plans/dialects/openclaw.md` (reference template); `plans/dialects/letta.md` (the second dialect, for comparison); `plans/generated-package-shape.md` (output shape).
+
+---
+
+## What this document does
+
+Describes the concrete rules melleafy applies when processing a **Claude Code** source spec. Claude Code is a **strict superset of the Agent Skills open standard** — every field in Agent Skills std works, plus roughly a dozen Claude Code extensions. In the v1 supported runtime set, Claude Code is the most widely used and the most feature-rich.
+
+Key Claude Code concepts readers should have in mind:
+
+- **Skill locations with precedence**: managed > user (`~/.claude/skills/`) > project (`.claude/skills/`) > plugin.
+- **CLAUDE.md hierarchy**: project CLAUDE.md, private `CLAUDE.local.md` (ignored), user-level `~/.claude/CLAUDE.md`, walked upward from the spec directory to the repo root.
+- **`@path/file` imports**: resolve recursively to depth 5.
+- **Settings JSON**: `.claude/settings.json`, `.claude/settings.local.json`, `~/.claude/settings.json` (plus managed). Contains `permissions`, `env`, `hooks`, `mcpServers`, `defaultMode`.
+- **Subagents**: `.claude/agents/*.md` — nested agent specs with their own frontmatter.
+- **Plugin manifests**: `.claude-plugin/plugin.json` (required `name`), `.claude-plugin/marketplace.json`.
+- **Slash commands and skills have merged** — both create `/name`, share the same frontmatter; when both exist the skill wins.
+
+---
+
+## 1. Detection signals
+
+Step 0 classifies a spec as Claude Code when signals match. Because Claude Code is a superset of Agent Skills std, careful distinction is needed — a spec with *only* Agent Skills fields belongs to that runtime, not Claude Code.
+
+| Signal | Strength | Notes |
+|---|---|---|
+| `.claude/` directory present in workspace root or any ancestor | strong | The defining artefact — presence indicates Claude Code environment |
+| Frontmatter field `disable-model-invocation` | strong | Not in Agent Skills std; Claude Code–specific |
+| Frontmatter field `user-invocable` | strong | Claude Code–specific |
+| Frontmatter field `context: fork` | strong | Subagent context forking — Claude Code–specific |
+| Frontmatter field `agent:` (subagent reference) | strong | Claude Code–specific |
+| Frontmatter field `hooks:` at skill level | strong | Skill-scoped hooks — Claude Code extension of Agent Skills |
+| Frontmatter field `paths:` (glob list for auto-load) | strong | Claude Code–specific |
+| Frontmatter field `shell: bash \| powershell` | medium | Claude Code has this field; no other Tier-1 runtime does |
+| Frontmatter field `argument-hint` or `arguments` | medium | Slash-command-specific fields |
+| Frontmatter field `model:` | medium | Model pinning; Claude Code–specific in skills |
+| Frontmatter field `effort:` | medium | Reasoning-effort pinning |
+| Spec file is under `.claude/skills/`, `.claude/commands/`, or `.claude/agents/` | strong | Canonical Claude Code locations |
+| `.claude/settings.json` present anywhere in workspace | strong | Settings JSON is always present in real Claude Code projects |
+| `.mcp.json` present | medium | Also used by some non-Claude-Code MCP clients, but common in Claude Code |
+| `.claude-plugin/plugin.json` present | medium | Plugin manifest; Claude Code–specific |
+| `CLAUDE.md` file present at any level | medium | Not uniquely Claude Code (projects sometimes include it as convention) but strongly suggestive in combination |
+
+**Disambiguating from Agent Skills std.** If the *only* matching signal is `SKILL.md` with standard frontmatter (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`), and no Claude-Code-specific fields or locations, classify as Agent Skills std. Presence of any Claude Code extension (field or location) elevates to Claude Code.
+
+**Precedence note.** Per R1's tiebreak order: Agent Skills std > Claude Code. If signal counts are exactly equal, Agent Skills std wins. But in practice the extension-field signals are "strong" and typically tip the count clearly toward Claude Code.
+
+**Hybrid threshold.** A Claude Code project that also uses OpenClaw (as a development harness while targeting a different runtime) is a plausible Hybrid. Signals within 1 of another runtime trigger Hybrid per R1.
+
+---
+
+## 2. File inventory rules (Step 1a)
+
+Claude Code's workspace is richer than OpenClaw's — more distinct file roles, upward directory walking, and multiple skill locations with precedence. Step 1a must assemble the full inventory across all these surfaces.
+
+### 2a. Skill / command / agent files (the primary spec)
+
+The primary spec is the `SKILL.md` (or `.md` under `.claude/commands/` or `.claude/agents/`) the user passed on the command line.
+
+| File | Role in spec | Inventory action |
+|---|---|---|
+| Primary spec file with Claude Code frontmatter | C1 Identity + C2 Operating rules + C6 Tool declarations via `allowed-tools` | Parse frontmatter; body is decomposed per Step 1b |
+| `SKILL.md` body | Mixed — depends on content | Decomposed by Step 1b |
+
+**Rule 2a-1**: melleafy reads the spec file exactly once, even if multiple SKILL.md files exist at different precedence tiers. The one passed on the command line wins; others are noted in the report but not inventoried.
+
+### 2b. Upward-walking CLAUDE.md
+
+CLAUDE.md files accumulate rules from every ancestor directory up to the repo root (detected by `.git`) or the user's home directory, whichever comes first.
+
+| File | Role | Inventory action |
+|---|---|---|
+| `./CLAUDE.md` (sibling to spec) | C1 Identity (project-level) | Read; contribute elements |
+| `../CLAUDE.md` | Same | Read; contribute elements |
+| Walking upward until repo root | Same | Read each; contribute elements |
+| `~/.claude/CLAUDE.md` (user-level) | C3 User facts (user-level defaults) | Read; contribute elements |
+| `./CLAUDE.local.md` (private) | — | **Ignore** — Claude Code treats this as user-private, not spec content |
+| Managed enterprise CLAUDE.md | — | Detection only; do not inventory — may contain enterprise rules melleafy should not reproduce |
+
+**Rule 2b-1**: the upward walk stops at the first of: the repo root (directory containing `.git`), the user's home directory, or the filesystem root. It does not cross filesystem boundaries.
+
+**Rule 2b-2**: topmost CLAUDE.md (closest to the spec) is "most specific"; `~/.claude/CLAUDE.md` is "most general." When contributing elements to the inventory, more specific CLAUDE.md files' elements get higher `element_id` numbers (because they're read later in the traversal), so source order in `inventory.json` roughly matches specificity.
+
+**Rule 2b-3**: `--add-dir` roots from the Claude Code CLI are **not** inventoried by default. The environment variable `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` would enable this, but melleafy does not honour it in v1 — reading arbitrary directories introduces scope ambiguity. Flagged as a v2 option.
+
+### 2c. `.claude/` directory
+
+The `.claude/` directory lives in the workspace root (or any ancestor, but the closest to the spec wins). It contains:
+
+| File / Path | Role | Inventory action |
+|---|---|---|
+| `.claude/settings.json` | C2 Operating rules + C7 Credentials + C6 Tools + C9 Scheduling | Parse JSON; each top-level key becomes a source of multiple elements |
+| `.claude/settings.local.json` | Same, but user-private | Parse and merge per deep-merge rules; mark merged elements with `source: "local"` |
+| `~/.claude/settings.json` | Same, user-level defaults | Parse and merge; mark as `source: "user"` |
+| `.claude/agents/*.md` | Subagents — cross-skill references (C10-like, currently deferred) | Record existence; do not fully inventory content in v1 |
+| `.claude/skills/<name>/SKILL.md` | Other skills in the project | Detection only — v1 doesn't reproduce multi-skill packages |
+| `.claude/commands/*.md` | Other slash commands in the project | Detection only |
+| `.claude/hooks/hooks.json` (if plugin-bundled) | C9 Scheduling (event-triggered) + C2 Operating rules | Parse and merge with settings.json hooks |
+
+**Rule 2c-1**: `.claude/settings.local.json` contains user-private overrides. Step 1a reads it but any credentials or workstation-specific paths found are flagged with `sensitive: true` — they must not end up in the generated package's `config.py`.
+
+**Rule 2c-2**: the `defaultMode` field in settings.json is a runtime default for permission mode (`default | acceptEdits | plan | bypassPermissions | auto | dontAsk`). `plan` mode has modality implications (see §5).
+
+**Rule 2c-3**: subagents in `.claude/agents/*.md` are related agent specs. v1 melleafy does not expand them — each is its own spec that should be processed separately. The mapping report records subagent references as cross-skill references in the Provenance appendix.
+
+### 2d. MCP server configuration
+
+| File | Role | Inventory action |
+|---|---|---|
+| `.mcp.json` in workspace root | C6 Tools (external MCP servers) | Parse; each `mcpServers.<name>` becomes a tool-declaration element |
+| `mcpServers` block within `.claude/settings.json` | Same | Merged with `.mcp.json` per settings-merge rules |
+
+**Rule 2d-1**: MCP tools use the naming convention `mcp__<server>__<tool>` when referenced from `allowed-tools` or from the pipeline body. The inventoried element preserves this naming.
+
+**Rule 2d-2**: an MCP server declared in settings but with no `allowed-tools` entry referencing any of its tools is an "unused MCP server." Step 7's cross-reference lint flags this as a warning.
+
+### 2e. Plugin manifests
+
+| File | Role | Inventory action |
+|---|---|---|
+| `.claude-plugin/plugin.json` | C8 Runtime env (plugin metadata) | Parse; `name`, `version`, `dependencies` become C8 elements |
+| `.claude-plugin/marketplace.json` | C8 Runtime env (plugin discovery) | Detection only — v1 does not reproduce marketplace bundling |
+
+### 2f. `@path/file` imports
+
+Claude Code supports `@path/file` references in spec bodies and CLAUDE.md files. These resolve recursively up to depth 5 and the referenced file's content becomes part of the inventory.
+
+**Rule 2f-1**: melleafy resolves `@` references during Step 1a. Each referenced file is added to the file list with `role: "C1/C2/C3 inline import from <source_file>"` (category inferred from referenced file content and the context of the reference).
+
+**Rule 2f-2**: cycles are detected (A imports B, B imports A) and broken — the second encounter of any file is skipped with a warning.
+
+**Rule 2f-3**: depth beyond 5 is also a warning; the 5-deep file is inventoried, deeper imports are not followed.
+
+### 2g. Credential locations
+
+| Location | Platform | Inventory action |
+|---|---|---|
+| macOS Keychain `Claude Code-credentials` | macOS | **Detection only** — never read from Keychain; never access user credentials |
+| `~/.claude/.credentials.json` (mode 0600) | Linux / Windows | **Detection only** — record existence for SETUP.md §2, never read contents |
+| `settings.env` in settings.json | Cross-platform | Read the env-var *names*, never the values |
+| `apiKeyHelper` script reference in settings.json | Cross-platform | Record existence; never execute |
+
+**Rule 2g-1**: Claude Code's credential resolution order is: cloud provider → `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `apiKeyHelper` → `CLAUDE_CODE_OAUTH_TOKEN` → subscription OAuth. Melleafy documents this order in SETUP.md §2 for packages whose generated code reads Anthropic credentials; it does not reproduce the resolution logic.
+
+### 2h. Workspace root determination
+
+For Claude Code, the "workspace root" (per Step 1a §1a.1) is the first ancestor directory containing any of: `.claude/`, `.git/`, or the user's home directory. This is distinct from OpenClaw (where workspace = spec's parent) because Claude Code's multi-file structure spans directories.
+
+**Rule 2h-1**: when an ancestor has `.git/` but no `.claude/`, treat the git root as workspace root. This lets melleafy find CLAUDE.md files above the spec.
+
+**Rule 2h-2**: if the spec is outside any git repo and has no `.claude/` ancestor, fall back to the spec's parent directory. Warn in the inventory report that workspace scope may be incomplete.
+
+### 2i. Missing files
+
+Absence handling:
+
+- `.claude/settings.json` absent: normal; the spec may be self-contained. No warning.
+- `CLAUDE.md` absent anywhere: normal; not every project has one.
+- `.mcp.json` absent: normal; many skills use no MCP servers.
+- `.claude-plugin/` absent: normal; most skills aren't plugins.
+
+No Claude Code source file is strictly required beyond the primary spec itself.
+
+---
+
+## 3. Frontmatter rules
+
+Claude Code frontmatter is YAML — same parsing machinery as OpenClaw. The field set is larger.
+
+### 3a. Agent Skills std fields (inherited)
+
+| Field | Source | Notes |
+|---|---|---|
+| `name` | Agent Skills std | Required; ≤64 chars (quietly changed from 40 in PR #350) |
+| `description` | Agent Skills std | Required |
+| `license` | Agent Skills std | Optional |
+| `compatibility` | Agent Skills std | Optional; free text, ≤500 chars |
+| `metadata` | Agent Skills std | Optional dict |
+| `allowed-tools` | Agent Skills std (experimental) | Space-separated string; in Claude Code this pre-approves tools (doesn't restrict) |
+| `when_to_use` | Community convention | Not in the Agent Skills validator's allow-list; Claude Code treats as description supplement |
+
+### 3b. Claude Code extensions
+
+| Field | Type | Semantics |
+|---|---|---|
+| `disable-model-invocation` | bool | Skill is never auto-loaded by model; user-invocable only |
+| `user-invocable` | bool | Appears as a `/name` command |
+| `context: fork` | literal | Creates a forked context (subagent-like) when invoked |
+| `agent` | string | Delegate to a named subagent |
+| `hooks` | dict | Skill-scoped lifecycle hooks (PreToolUse, PostToolUse, Stop) |
+| `paths` | list of glob strings | Auto-load when editing matching files |
+| `shell` | `"bash"` \| `"powershell"` | Shell for any bash-tool invocations |
+| `argument-hint` | string | Human-readable hint for slash-command arguments |
+| `arguments` | list of dicts | Structured arguments for slash commands |
+| `model` | string | Pin a model for this skill |
+| `effort` | `"low"` \| `"medium"` \| `"high"` | Reasoning effort hint |
+
+### 3c. Subagent frontmatter
+
+Files under `.claude/agents/*.md` have additional fields:
+
+| Field | Type | Semantics |
+|---|---|---|
+| `tools` | list | Tool allowlist (NOT the same as `allowed-tools`, which pre-approves) |
+| `disallowedTools` | list | Explicit denylist |
+| `permissionMode` | enum | `acceptEdits` / `plan` / `bypassPermissions` / `default` / `dontAsk` |
+| `maxTurns` | int | Cap on turn count |
+| `skills` | list | Preloads full skill content (distinct from main sessions, where only descriptions are loaded) |
+| `mcpServers` | list | MCP server allowlist for this subagent |
+| `memory` | `"user"` \| `"project"` \| `"local"` | Enables persistent `~/.claude/agent-memory/MEMORY.md` |
+| `background` | bool | Runs in background |
+| `isolation` | literal (`"worktree"`) | Git worktree isolation |
+| `color` | string | UI hint |
+| `initialPrompt` | string | Initial prompt for the subagent |
+
+**Rule 3c-1**: v1 melleafy does not expand subagents into the generated package. Subagent files are detected and their existence recorded, but their content is not inventoried as part of the primary spec.
+
+**Rule 3c-2**: **plugin-bundled subagents cannot use `hooks`, `mcpServers`, or `permissionMode`** (Claude Code security rule). If these fields appear in a plugin-bundled subagent, Step 1a records the anomaly in the inventory report.
+
+### 3d. Frontmatter parsing and validation
+
+Frontmatter is parsed with `yaml.safe_load`. Claude Code–specific fields are validated against the field set above. Unknown fields are not errors — Claude Code itself accepts them — but they're flagged in the inventory report with `unknown_frontmatter_field: true` for reviewer awareness.
+
+### 3e. Slash command vs skill disambiguation
+
+When a file could be either a slash command (under `.claude/commands/`) or a skill (under `.claude/skills/`), the path determines which it is. If both locations have files with the same name, **skills win** per Claude Code's merge rule. Inventory records the precedence outcome.
+
+---
+
+## 4. Dialect mapping table
+
+This table covers the most common Claude Code source signals. Rows are ordered by the mapping table convention (category within file-type).
+
+| Source signal | Category | Default disposition | Generation target |
+|---|---|---|---|
+| `name` frontmatter field | — | `bundle` | `pyproject.toml:name`, `README.md` title, `__init__.py:__agent_name__` |
+| `description` frontmatter field | C1 | `bundle` | `config.AGENT_DESCRIPTION` |
+| `license` frontmatter field | — | `bundle` | `pyproject.toml:license`, `LICENSE` file generated if upstream file exists |
+| `compatibility` frontmatter field | C8 | `bundle` | `config.COMPATIBILITY_NOTE`; appears in README |
+| `metadata.*` frontmatter fields | — | `bundle` | `config.METADATA` dict |
+| `allowed-tools` entries | C6 | Varies per entry type (see below) | `tools.py` or `constrained_slots.py` |
+| `allowed-tools` entry `Bash(pattern)` | C6 | `stub` | `constrained_slots.py:run_bash` (shell execution is host-needing) |
+| `allowed-tools` entry `Read(path-glob)`, `Write(...)`, `Edit(...)` | C6 | `stub` | `constrained_slots.py:*`; filesystem I/O deferred to host |
+| `allowed-tools` entry `WebFetch(domain:*.example.com)` | C6 | `real_impl` | `tools.py:web_fetch` using `requests` with URL allowlist |
+| `allowed-tools` entry `mcp__<server>__<tool>` | C6 | `stub` | `constrained_slots.py:<server>_<tool>`; SETUP.md §3 names the MCP server |
+| `disable-model-invocation: true` | C2 | *(informational)* | Noted in mapping report; affects Step 2.5b elicitation (can't be user-invocable) |
+| `user-invocable: true` | — | `bundle` | `main.py` argparse gets a `--user-invocable-mode` flag (informational) |
+| `context: fork` | C1 | *(not reproduced)* | Listed in "Runtime-specific constructs not reproduced" |
+| `agent: <name>` | — | *(not reproduced)* | Cross-skill reference; listed as deferred |
+| `hooks:` frontmatter dict | C9 (event_triggered) + C2 | `delegate_to_runtime` | Noted in mapping report; `handler.py` skeleton for each hook; SETUP.md §7 |
+| `paths:` frontmatter list | — | *(informational)* | Auto-load pattern — noted in README; not reproduced |
+| `shell: bash` or `powershell` | C8 | `bundle` | `config.DEFAULT_SHELL`; affects `run_bash` stub if used |
+| `argument-hint` / `arguments` | C3 | `external_input` | Pipeline parameter promotion via `main.py` |
+| `model: <name>` | C8 | `bundle` | `config.MODEL_NAME`; SETUP.md §3 explains backend-selection |
+| `effort: <level>` | C8 | `bundle` | `config.REASONING_EFFORT`; passed through to backend |
+| `SKILL.md` body — main content | Varies (C1, C2, C6 mixed) | Decomposed per Step 1b | Various |
+| `@path/file` import inside SKILL.md body | Resolved per §2f | Inherits the referenced file's category | Inherited target |
+| `CLAUDE.md` file — main content | C1 + C2 | `bundle` | Merged into `config.PREFIX_TEXT` and `requirements.py` rules |
+| `CLAUDE.md` imports via `@path` | Resolved per §2f | Inherits | Inherited |
+| `~/.claude/CLAUDE.md` content | C3 | `external_input` | User-level context — template suggests pipeline parameter with default |
+| `.claude/settings.json:permissions.allow[]` entries | C2 | `bundle` | Informational in `requirements.py` — Claude Code's permission allowlist becomes prose-only guidance (Mellea has no permission system) |
+| `.claude/settings.json:permissions.ask[]` entries | C2 + modality | `delegate_to_runtime` | `constrained_slots.py:confirm_action`; drives secondary `review_gated` modality |
+| `.claude/settings.json:permissions.deny[]` entries | C2 | `bundle` | `Requirement` with denying `validation_fn` (enforced) |
+| `.claude/settings.json:env[]` entries | C7 | `external_input` | `.env.example` entries |
+| `.claude/settings.json:hooks[]` entries | C9 (event_triggered) | `delegate_to_runtime` | `handler.py` skeletons; SETUP.md §7 names candidate host |
+| `.claude/settings.json:mcpServers[]` entries | C6 | `stub` (unless user overrides) | `constrained_slots.py` stub per MCP tool; SETUP.md §3 names MCP server |
+| `.claude/settings.json:defaultMode` | — | `bundle` | `config.DEFAULT_PERMISSION_MODE`; drives modality (see §5) |
+| `.mcp.json:mcpServers[]` | C6 | `stub` | Same as settings.json mcpServers |
+| `.claude-plugin/plugin.json:name` | — | `bundle` | `pyproject.toml:name` (uses plugin name if spec doesn't override) |
+| `.claude-plugin/plugin.json:dependencies[]` | C8 | `bundle` | Appended to `pyproject.toml:dependencies` |
+| `.claude-plugin/marketplace.json` contents | — | *(not reproduced)* | Noted; v1 doesn't produce marketplace bundles |
+| Hooks event: `PreToolUse`, `PostToolUse`, `Stop`, etc. | C9 (event_triggered) | `delegate_to_runtime` | Per hook, a handler stub; SETUP.md §7 |
+| Hooks matcher syntax (tool-name patterns) | — | `bundle` | Copied into handler stub docstrings |
+| JSON-on-stdin / exit-code hook contract | C8 | *(informational)* | Documented in SETUP.md §7 |
+| `/loop` scheduled task (session-scoped) | C9 (scheduled) | `delegate_to_runtime` | `config.SCHEDULE_CONFIG`; modality = `scheduled`; SETUP.md §6 explains session-scoped limitation |
+| Claude Code Routines (cloud cron) | — | *(not reproduced)* | Cloud-managed; no local spec representation |
+| Auto-memory `MEMORY.md` (≤200 lines or ≤25 KB injected) | C4 | `delegate_to_runtime` | `constrained_slots.py:recall_memory`; SETUP.md §4 |
+| Subagent `memory: user \| project \| local` | C5 | `delegate_to_runtime` | `constrained_slots.py:*`; SETUP.md §5 |
+| Subagent cross-reference via `agent:` field | — | *(deferred)* | Noted as cross-skill reference |
+
+**Override semantics.** Default dispositions can be overridden via `--dependencies=ask` or `config:<path>` per the standard R22 contract.
+
+**Rule 4-1**: the distinction between `allowed-tools` (Claude Code pre-approval — doesn't restrict) and subagent `tools` (strict allowlist) matters. Melleafy reads both but treats them differently in the mapping: `allowed-tools` informs which tools to generate; subagent `tools` is not reproduced because subagents aren't expanded in v1.
+
+---
+
+## 5. Modality signals (Step 0 Axis 5, R21)
+
+Claude Code has a richer modality declaration surface than most runtimes because it supports multiple invocation modes simultaneously.
+
+| Signal | Modality classification |
+|---|---|
+| Spec invoked via `claude -p` / `--print` | **`synchronous_oneshot`** — Claude Code's default headless mode |
+| `--output-format stream-json` referenced in spec body | **`streaming`** — same one-shot control flow, incremental output |
+| Spec invoked via `--resume` or `--continue` | **`conversational_session`** — JSONL state at `~/.claude/projects/` |
+| `/fork` or `--fork-session` referenced | **`conversational_session`** with branching — no v1-distinct modality, but noted in mapping report |
+| `permissionMode: "plan"` in settings or subagent | **`review_gated`** as secondary modality (primary depends on other signals) |
+| Hooks declared in settings.json or skill frontmatter | **`event_triggered`** as secondary modality |
+| `/loop [interval]` referenced or CronCreate tool usage | **`scheduled`** — session-scoped cron |
+| None of the above | **`synchronous_oneshot`** — the implicit default |
+
+**Composition.** Claude Code commonly composes modalities:
+
+- **`conversational_session` + `streaming`** — chatbot shape with incremental output. Very common.
+- **`synchronous_oneshot` + `review_gated`** — one-shot run that pauses for user approval in plan mode.
+- **`event_triggered` + `streaming`** — SessionStart hook that runs a streaming prompt.
+- **`scheduled` + `review_gated`** — a `/loop` task that requires approval before tool invocation. Awkward; flag for manual review.
+
+**Generated shape per R21.** The four composable primaries (`synchronous_oneshot`, `streaming`, `conversational_session`, `conversational + memory`) emit to shapes §5a–§5d. The host-needing modalities (`review_gated`, `scheduled`, `event_triggered`) fall back to `synchronous_oneshot` shape with SETUP.md §5/§6/§7 guidance.
+
+### 5a. `defaultMode` interaction
+
+`.claude/settings.json:defaultMode` affects modality as follows:
+
+- `default` → no modality change
+- `acceptEdits` → no modality change (behavior, not modality)
+- `plan` → `review_gated` secondary — the user reviews a plan before execution
+- `bypassPermissions` → no modality change (all permissions auto-approve)
+- `auto` → no modality change
+- `dontAsk` → no modality change
+
+**Rule 5a-1**: `plan` mode is the only `defaultMode` value that affects modality classification. It adds `review_gated` as a secondary modality; the primary stays whatever it otherwise would have been.
+
+### 5b. `/loop` limitations
+
+Claude Code's `/loop` scheduling is **session-scoped** — tasks persist only for the lifetime of the user's Claude Code session (7-day recurring expiry, 50 tasks max). This is a weaker scheduling contract than OpenClaw (persistent cron) or Letta (server-side persistent schedules).
+
+**Rule 5b-1**: when classifying as `scheduled` modality due to `/loop`, SETUP.md §6 names the limitation explicitly: "Claude Code `/loop` is session-scoped. For production deployment, use an external scheduler (cron, APScheduler, cloud CronJob)."
+
+### 5c. Claude Code Routines
+
+Claude Code Routines are Anthropic-cloud-managed scheduled runs with no local spec representation. **Melleafy cannot target Routines from local spec processing.** If a spec mentions Routines, it's recorded as deferred.
+
+---
+
+## 6. Quirks and workarounds
+
+### 6a. Settings merge order
+
+Settings are read from up to four locations and deep-merged:
+
+1. Managed enterprise settings (if present) — **highest precedence**; do not override
+2. `~/.claude/settings.json` (user)
+3. `.claude/settings.local.json` (user's project-private overrides)
+4. `.claude/settings.json` (project)
+
+For conflicting keys, the higher-precedence source wins. Array-valued keys (e.g., `permissions.allow[]`) are concatenated, not replaced. Permission rules are evaluated in the order **deny > ask > allow** regardless of which file they came from.
+
+Melleafy's inventory preserves the source file for each merged element: `source: "project" | "local" | "user" | "managed"`. This is surfaced in the mapping report so reviewers see where each rule originated.
+
+### 6b. `CLAUDE.local.md` is ignored
+
+`CLAUDE.local.md` is treated by Claude Code as user-private notes that should not be part of the committed spec. Melleafy ignores it entirely — never inventories, never warns about its presence. This is intentional: a user running melleafy on their own machine with `CLAUDE.local.md` containing personal notes should not accidentally ship those notes.
+
+### 6c. `allowed-tools` pre-approves, doesn't restrict
+
+The Agent Skills std `allowed-tools` field means "tools allowed." Claude Code extends the semantics: the list **pre-approves** tools (skipping the approval dialog), but the agent can still use tools not in the list if the user approves at runtime. This is subtly different from a strict allowlist.
+
+**Rule 6c-1**: melleafy treats `allowed-tools` as a set of tools to generate (all appear in `tools.py` or stubs), but does not enforce that only those tools are called. The generated pipeline may invoke additional tools if the source spec body references them. This is intentional — reproducing Claude Code's "pre-approval" semantics exactly would require runtime permission machinery Mellea doesn't have.
+
+### 6d. Subagent plugins can't use hooks/mcpServers/permissionMode
+
+Plugin-distributed subagents (those shipped via `.claude-plugin/plugin.json`) are forbidden from using `hooks`, `mcpServers`, or `permissionMode` fields (Claude Code security rule). Melleafy doesn't generate plugin-distributed anything in v1, but inventory records this invariant in the mapping report when the spec is a plugin-bundled subagent.
+
+### 6e. SDK vs CLI differences
+
+Claude Code has both a CLI (`claude -p ...`) and a Python SDK. Some frontmatter fields are CLI-only:
+
+- `allowed-tools` — CLI pre-approves; SDK ignores
+- `shell: bash` vs `powershell` — CLI controls the shell; SDK uses stdlib subprocess
+
+Melleafy produces Mellea Python packages that are SDK-callable. When the source spec declares CLI-only fields, they're recorded in the mapping report's "Runtime-specific constructs not reproduced" section.
+
+### 6f. Auto-compaction dropping context
+
+Claude Code auto-compacts long conversations by dropping older tool outputs then summarising. Invoked skills are re-attached to the summary with a **25,000-token combined budget, first 5,000 tokens per skill, oldest dropped first**. This is a runtime behavior that affects what the agent "sees" during execution.
+
+**Rule 6f-1**: melleafy does not reproduce auto-compaction. The generated Mellea pipeline processes its inputs directly. If the source spec relies on auto-compaction semantics (unlikely but possible for specs explicitly designed to work around it), those behaviors won't match between Claude Code and melleafy-generated output. Noted in the mapping report as an implicit runtime-specific construct.
+
+### 6g. `settings.env` vs `.env`
+
+Claude Code's `.claude/settings.json:env` is a **dict** of env-var definitions embedded in settings JSON. Regular `.env` files are also supported but distinct. Melleafy inventories both:
+
+- `settings.env` — C7 elements recorded with `source: "settings.json"`
+- `.env` files — C7 elements recorded with `source: ".env"`
+
+When a variable appears in both, the settings.json version wins (per Claude Code's merge rules).
+
+### 6h. MCP server allowlist per subagent
+
+Subagents have their own `mcpServers` allowlist — a subagent can use a subset of the project's MCP servers. Since v1 doesn't expand subagents, this is recorded but not enforced. If a v2 adds subagent expansion, the per-subagent MCP allowlist would drive which tools are available in each subagent's generated package.
+
+### 6i. `apiKeyHelper` script
+
+Claude Code supports an `apiKeyHelper` script that emits API keys on stdout. This is a credential-resolution mechanism, not a spec field. Melleafy records the reference in the mapping report (as a note in SETUP.md §2) but does not execute the script — executing arbitrary scripts is outside melleafy's scope per security principles.
+
+---
+
+## 7. Reference inventory output (illustrative)
+
+For a minimal Claude Code spec — a single `SKILL.md` with frontmatter, a project `CLAUDE.md`, and a `.claude/settings.json` with some hooks and permissions:
+
+### Inventory (abridged)
+
+```json
+{
+  "elements": [
+    {"element_id": "elem_001", "source_file": "CLAUDE.md", "source_lines": "1-15", "tag": "CONFIG", "category": "C1", "content_summary": "Project-level persona"},
+    {"element_id": "elem_010", "source_file": "SKILL.md", "source_lines": "frontmatter.description", "tag": "CONFIG", "category": "C1", "content_summary": "Skill description"},
+    {"element_id": "elem_011", "source_file": "SKILL.md", "source_lines": "frontmatter.allowed-tools", "tag": "TOOL_TEMPLATE", "category": "C6", "content_summary": "Tools: Bash, Read, Write"},
+    {"element_id": "elem_020", "source_file": "SKILL.md", "source_lines": "25-40", "tag": "ORCHESTRATE", "category": "C2", "content_summary": "Extraction-and-summarisation workflow"},
+    {"element_id": "elem_050", "source_file": ".claude/settings.json", "source_lines": "json:permissions.deny[0]", "tag": "VALIDATE_OUTPUT", "category": "C2", "content_summary": "Never run `rm -rf`"},
+    {"element_id": "elem_051", "source_file": ".claude/settings.json", "source_lines": "json:hooks.PreToolUse[0]", "tag": "ORCHESTRATE", "category": "C9", "content_summary": "PreToolUse hook: log every tool call"}
+  ]
+}
+```
+
+Note `source_lines` formats: line ranges for Markdown; `frontmatter.<field>` for frontmatter references; `json:<jq-path>` for JSON imports (same convention as Letta dialect §7).
+
+### Element mapping (abridged)
+
+```json
+{
+  "mappings": [
+    {"element_id": "elem_001", "target_file": "config.py", "target_symbol": "PREFIX_TEXT", "primitive": "bundle"},
+    {"element_id": "elem_010", "target_file": "config.py", "target_symbol": "AGENT_DESCRIPTION", "primitive": "bundle"},
+    {"element_id": "elem_011", "target_file": "constrained_slots.py", "target_symbol": "run_bash", "primitive": "stub"},
+    {"element_id": "elem_020", "target_file": "pipeline.py", "target_symbol": "run_pipeline", "primitive": "orchestrate"},
+    {"element_id": "elem_050", "target_file": "requirements.py", "target_symbol": "OPERATING_REQUIREMENTS", "primitive": "requirement"},
+    {"element_id": "elem_051", "target_file": "handlers/pre_tool_use.py", "target_symbol": "handle_pre_tool_use", "primitive": "delegate"}
+  ]
+}
+```
+
+### Dialect-specific notes in the mapping report
+
+- A "Runtime-specific constructs not reproduced" section listing `context: fork`, `/loop` session-scoped limitations, auto-compaction semantics, `defaultMode: plan`, plugin `.claude-plugin/marketplace.json`.
+- A "Settings merge order" note if `.claude/settings.local.json` was present, explaining which settings were overridden.
+- An "Upward-walking CLAUDE.md" note listing which ancestor CLAUDE.md files were inventoried.
+- A "Hook delegation" note listing which hooks were detected and are stubbed in `handlers/`.
+
+---
+
+## 8. Deferred Claude Code features (not handled in v1)
+
+- **Subagent expansion.** `.claude/agents/*.md` subagents are detected but not inventoried. v2 could expand each into its own generated package linked by cross-reference.
+- **Plugin bundling.** `.claude-plugin/plugin.json` is read for metadata but v1 doesn't emit plugin bundles.
+- **Marketplace manifests.** `.claude-plugin/marketplace.json` is informational only.
+- **Cross-skill references** via `agent:` field or Agent tool invocations — noted but not resolved.
+- **`context: fork` runtime behavior** — v1 doesn't reproduce forked contexts.
+- **`--add-dir` roots with `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1`** — not honoured in v1.
+- **Claude Code Routines** (cloud-managed cron) — no local spec representation; cannot target.
+- **Auto-compaction exact semantics** — v1 Mellea packages don't reproduce the token-budget context management.
+- **`apiKeyHelper` script execution** — recorded as a reference; v1 never executes user scripts.
+- **Permission resolution `deny > ask > allow`** — partially honoured (deny becomes validating `Requirement`; ask becomes `review_gated` stub; allow becomes prose). Full semantics would require runtime permission middleware.
+
+---
+
+## 9. Cross-references
+
+- `spec.md` R1, R21, R22 — the contracts this dialect implements
+- `spec.md` Deferred Items — especially harness adapter, native memory backend, cross-skill references
+- `plans/dialects/openclaw.md` — template this dialect adapts
+- `plans/dialects/letta.md` — a differently-shaped dialect for comparison (single JSON file)
+- `plans/generated-package-shape.md` — what the generated package looks like
+- `glossary.md` — `dialect`, `disposition`, `interaction modality`
+- `melleafy.json` schema — the manifest fields this dialect populates
+
+---
+
+## 10. Ratification notes
+
+This dialect doc v1.0.0 was the third drafted, selected for being the most feature-rich and widely-used runtime in the v1 supported set.
+
+**What the template survived unchanged:**
+- Section 1 (Detection signals) — worked identically; the signal-count model accommodates Claude Code's many signals without restructure.
+- Section 4 (Dialect mapping table) — the four-column shape accommodates Claude Code's many source signals. The table is the longest among the three dialect docs written so far, but the structure is the same.
+- Section 5 (Modality signals) — composition is the biggest workout here; the section's format handles multi-modality well.
+- Sections 6–10 — translated directly.
+
+**What the template needed to adapt:**
+- Section 2 (File inventory) — became substantially more complex because Claude Code has multiple distinct surfaces (SKILL.md, CLAUDE.md hierarchy, `.claude/` directory, `.mcp.json`, plugin manifests, credentials). The section is organised as nine sub-sections (2a–2i) rather than OpenClaw's handful. The template handled this by allowing Section 2 to have as many sub-sections as needed.
+- Section 3 (Frontmatter) — expanded to three sub-sections (Agent Skills inherited, Claude Code extensions, subagent additions) because Claude Code's frontmatter is richer and has field-inheritance semantics. Template accommodated without restructure.
+- Section 7 (Reference inventory output) — uses the same `source_lines` convention extensions as Letta (`json:<path>`, `frontmatter.<field>`). These are now two data points for formalising the convention in Step 1b.
+
+**What this tells us about template generality.** Three dialects (OpenClaw, Letta, Claude Code) with three different source shapes — Markdown workspace, single JSON file, Markdown workspace with upward-walking directory structure — all fit the 10-section template. The template is sufficiently general for the Tier-1 runtimes.
+
+Open questions:
+
+- **§2b upward-walking CLAUDE.md** stops at the git repo root. For monorepo setups with multiple projects in one git repo, this could over-inventory (reading CLAUDE.md files from sibling project directories). v1 accepts this; v2 could add a `--workspace-scope=skill|project|repo` flag. Flagged for later.
+- **§4 mapping table for `allowed-tools`** categorises each tool pattern type (`Bash(...)`, `Read(...)`, `WebFetch(...)`, `mcp__...`) into disposition defaults. The Bash/Read/Write/Edit tools default to `stub` because shell/filesystem execution is host-needing; `WebFetch` defaults to `real_impl` because HTTP fetching is Python-native. This asymmetry is deliberate but worth corpus-testing — real Claude Code specs may have patterns the table doesn't cover (e.g., `Notebook*` tools).
+- **§5a `defaultMode: plan` affecting modality** — I classified this as adding `review_gated` secondary. Alternative: `plan` is a behavior (not modality) and shouldn't affect classification. Defensible both ways; sticking with the modality interpretation because the generated package's control flow would genuinely differ (emit a "plan preview" step) — which is a modality-level choice.
+- **§6c `allowed-tools` pre-approval semantics** — I deliberately chose to not enforce the "only these tools" interpretation because Mellea has no permission machinery. This means generated packages may call tools the user hasn't "pre-approved," which is subtly different behavior from the source spec. Worth highlighting in README prominently.
+- **§2f `@path/file` imports recurse to depth 5** — matches Claude Code's own limit. Cycle detection is specified; total-file-count limits are not. A deeply-connected spec could pull in many files. Step 1a's 50 MB workspace cap acts as a backstop.
+- **Subagent `skills:` preloading** is a distinctive Claude Code feature — subagents see full skill content, not just descriptions. Since v1 doesn't expand subagents, this is deferred, but it could affect how melleafy handles multi-skill packages in v2.
+- **§2g credentials handling** lists platforms separately. The underlying resolution order (§2g rule 2g-1) is common across platforms; the difference is only storage location. Could be simplified to "detection only; platform-specific" without losing information.

--- a/docs/dialects/crewai.md
+++ b/docs/dialects/crewai.md
@@ -1,0 +1,433 @@
+# CrewAI Dialect
+
+**Version**: 1.0.0
+**Status**: Sixth dialect doc. YAML + Python hybrid source model — tests the template against a runtime with two declarative files plus executable code, and with Flows as an optional higher-order composition layer.
+
+**Prerequisite reading**: `spec.md` R1 (detection), R22 (dialect mapping contract), R21 (modality); `plans/dialects/openclaw.md` (reference template for Markdown workspaces); `plans/dialects/langgraph.md` (reference for code-first dialects); `plans/generated-package-shape.md` (output shape); `plans/steps/step-1a-inventory.md`, `plans/steps/step-1b-tagging.md`.
+
+---
+
+## What this document does
+
+Describes the rules melleafy applies when processing a **CrewAI** source spec. CrewAI is YAML-first but code-adjacent: two declarative YAML files under `config/` (`agents.yaml`, `tasks.yaml`) describe the agents and tasks; Python files (`tools.py`, `crew.py`) carry executable content that references the YAML declarations. An optional higher layer — **Flows** (`@start`/`@listen`/`@router`/`@persist`) — composes crews into orchestrated pipelines.
+
+CrewAI is the first dialect written here whose source model is genuinely **dual** — declarative and executable surfaces together, each complementing the other. The template's inventory section adapts by enumerating both surfaces.
+
+Key CrewAI concepts readers should have in mind:
+
+- **Crew**: a group of agents executing tasks, orchestrated by a `Process` (sequential or hierarchical).
+- **`agents.yaml`**: per-agent declarations — `role`, `goal`, `backstory`, `llm`, `tools`, `memory`, `allow_delegation` (default **False**), `allowed_agents`, and more.
+- **`tasks.yaml`**: per-task declarations — `description`, `expected_output`, `agent` reference, `context: [task_a, task_b]` for task-level dependencies, `async_execution`, `output_pydantic`, `human_input`, plus callbacks and guardrails.
+- **`tools.py`**: `@tool`-decorated functions or `BaseTool` subclasses; MCP integration via `MCPServerAdapter`.
+- **`crew.py`**: assembly logic; often uses `@CrewBase` for auto-resolution.
+- **Flows**: separate composition layer using `@start`, `@listen`, `@router`, `@persist` decorators. Flows can call crews via `SomeCrew().crew().kickoff(inputs=...)`.
+- **Memory backends**: filesystem-based (Chroma for STM/entity/knowledge, SQLite for LTM) under `~/Library/Application Support/CrewAI/<project>/` (macOS), `~/.local/share/CrewAI/<project>/` (Linux), or `CREWAI_STORAGE_DIR` override.
+
+---
+
+## 1. Detection signals
+
+| Signal | Strength | Notes |
+|---|---|---|
+| `config/agents.yaml` AND `config/tasks.yaml` present | strong | The canonical CrewAI layout |
+| `@CrewBase`, `@agent`, `@task`, `@crew` decorators in any `.py` file | strong | CrewAI-specific decorator set |
+| `from crewai import Agent, Task, Crew` or similar | strong | Canonical import |
+| `from crewai.flow.flow import Flow` + `@start`, `@listen`, `@router` decorators | strong | Flows signal |
+| `.crewai/memory` directory in workspace | medium | Persistence artifact; survives across runs |
+| `@crewai_event_bus.on(...)` | medium | Event-listener pattern |
+| `tools.py` file at workspace root referencing `@tool` from `crewai.tools` | medium | Tool-declaration file |
+| `Chroma` usage with CrewAI-style paths (`chroma.sqlite3`, `entities/`, `knowledge/`) | weak | Persistence pattern |
+| `MCPServerAdapter` import | weak | MCP integration |
+
+**Disambiguating from LangGraph.** Both have `Agent` in the import namespace, but the decorator sets are distinct. LangGraph uses `StateGraph`, `add_node`, `add_edge`; CrewAI uses `@agent`, `@task`, `@crew`. A spec importing both is Hybrid.
+
+**Disambiguating from OpenAI Agents SDK.** Both have `@tool` decorators, but CrewAI's `@tool` is `from crewai.tools import tool` whereas Agents SDK uses `from agents import function_tool`. Also, Agents SDK uses pure Python Agent class construction; CrewAI emphasizes YAML declarations.
+
+**Precedence note.** R1 tiebreak: CrewAI wins over LangGraph in exact ties. This happens rarely — CrewAI's YAML signals usually tip the count clearly.
+
+**Hybrid threshold.** CrewAI + LangGraph is an uncommon but real Hybrid (a project that uses Flows to orchestrate at a higher level and LangGraph for internal reasoning loops). Detected by presence of both signal sets; follows R1's 1-signal-difference threshold.
+
+---
+
+## 2. File inventory rules (Step 1a)
+
+CrewAI's workspace is structured: YAML under `config/`, Python at root, memory at system-specific locations.
+
+### 2a. Primary declarative surfaces
+
+| File | Role | Inventory action |
+|---|---|---|
+| `config/agents.yaml` | Agent declarations — C1 (identity) + C2 (rules) + C6 (tool bindings) per agent | Parse YAML; each top-level agent key becomes a source of multiple elements |
+| `config/tasks.yaml` | Task declarations — C2 (rules/dependencies) + C3 (inputs via `kickoff`) | Parse YAML; each top-level task key becomes a source |
+
+### 2b. Primary executable surfaces
+
+| File | Role | Inventory action |
+|---|---|---|
+| `tools.py` (at workspace root) | C6 Tools — `@tool` functions, `BaseTool` subclasses | Parse with AST; each decorated function / subclass becomes a C6 element |
+| `crew.py` (at workspace root) | Assembly logic — `@CrewBase` methods, crew construction | Parse with AST; methods mapped to agent/task references |
+| Any `.py` file with CrewAI decorators or imports | Additional assembly or utility | AST-walked per `plans/dialects/langgraph.md` §2 pattern |
+
+**Rule 2b-1**: `crew.py` with `@CrewBase` decoration has implicit path resolution — `@agent` and `@task` decorated methods correspond to entries in `agents.yaml` and `tasks.yaml` by name. Melleafy's Step 1b cross-references the YAML names against the Python method names and surfaces mismatches in the inventory report.
+
+**Rule 2b-2**: `crew.py` may use explicit construction (not `@CrewBase`) — `Agent(...)`, `Task(...)`, `Crew([...])` calls in module body. AST-walked the same way; the resulting elements are tagged identically regardless of construction style.
+
+### 2c. Flows surface (optional higher-order layer)
+
+If the project uses Flows (detected via `@start`, `@listen`, `@router`, `@persist` decorators or `Flow` imports):
+
+| File | Role | Inventory action |
+|---|---|---|
+| Any `.py` file with Flow decorators | Orchestration layer atop crews | AST-walk for `@start`/`@listen`/`@router`/`@persist`/`@human_feedback` decorated methods |
+| Flow class definitions (`class MyFlow(Flow[StateType])`) | State-carrying composition | Inventory state type as a SCHEMA element; methods as ORCHESTRATE elements |
+
+**Rule 2c-1**: Flows compose crews. A `@start`-decorated method typically calls `SomeCrew().crew().kickoff(inputs=...)`. When melleafy detects this pattern, the crew reference is recorded but the crew's own YAML is *not* re-inventoried from scratch — the crew entries are referenced by name.
+
+**Rule 2c-2**: a project may be crew-only, flow-only (flows without nested crews), or crew+flow. Detection produces a sub-variant recorded in the mapping report: `crewai_sub_variant ∈ {crew_only, flow_only, crew_and_flow}`.
+
+### 2d. Supporting files
+
+| File | Role | Inventory action |
+|---|---|---|
+| `.env` at workspace root | C7 credentials — CrewAI auto-calls `load_dotenv()` | Parse; one element per var |
+| `.env.example` | C7 credential template | Same |
+| `pyproject.toml` / `requirements.txt` | C8 dependencies | Parse; elements per package |
+| `README.md` | Free-form | NO_DECOMPOSE unless spec references |
+
+**Rule 2d-1**: CrewAI's auto-`load_dotenv()` means `.env` handling is implicit — the generated pipeline must reproduce this behavior (via python-dotenv in `main.py`). The mapping report documents this convention under "Runtime behaviors preserved."
+
+### 2e. Memory backend artifacts (detection only)
+
+| Path | Type | Inventory action |
+|---|---|---|
+| `~/Library/Application Support/CrewAI/<project>/` (macOS) | Memory root | **Detection only** — do not read contents |
+| `~/.local/share/CrewAI/<project>/` (Linux) | Memory root | Same |
+| `$CREWAI_STORAGE_DIR/<project>/` (override) | Memory root | Same |
+| `chroma.sqlite3` under any of above | Short-term memory | Detection only |
+| `long_term_memory_storage.db` | Long-term memory | Detection only |
+| `entities/` subdirectory | Entity memory | Detection only |
+| `knowledge/` subdirectory | Knowledge base | Detection only |
+
+**Rule 2e-1**: memory backends are **detection-only** — their existence confirms that the spec has been run locally, but their contents are runtime state, not spec content. Bundling them would inline user-specific data into the generated package. The mapping report's Classification section notes "CrewAI memory backends detected; contents not inventoried (runtime state)."
+
+**Rule 2e-2**: Chroma lock files (`chroma.sqlite3-journal`, etc.) prevent concurrent writes. If the workspace has multiple CrewAI projects sharing the same `CREWAI_STORAGE_DIR`, parallel runs would conflict. Melleafy flags this as a lint in Step 7's category-specific lint (C4/C5 section), but detection-time only — no halt.
+
+### 2f. Missing files
+
+Absence rules:
+
+- `config/agents.yaml` absent + `@agent`-decorated methods exist in `.py`: normal — some projects define agents purely in code. Proceed with Python inventory.
+- `config/tasks.yaml` absent + `@task`-decorated methods exist: same.
+- Both YAML files absent AND no decorators: detection likely misfired; halt with diagnostic.
+- `tools.py` absent: normal; crews may use only built-in or hosted tools.
+- `crew.py` absent + `@CrewBase` not used: the project may rely on YAML-only crew definition; still proceed.
+
+---
+
+## 3. Structured-content rules
+
+CrewAI has three kinds of structured content: YAML (under `config/`), Python AST (`.py` files), and `.env` text format.
+
+### 3a. YAML parsing
+
+Parsed with `yaml.safe_load`. Per-file validation:
+
+**For `agents.yaml`**: each top-level key is an agent name. Per agent, fields include `role`, `goal`, `backstory`, `llm`, `tools` (list of tool names), `memory` (bool), `allow_delegation` (bool, default False), `allowed_agents` (list of agent names), `max_iter`, `max_rpm`, `respect_context_window`, `reasoning`, `multimodal`, `cache`, `step_callback`, `system_template`, `prompt_template`, `response_template`.
+
+**For `tasks.yaml`**: each top-level key is a task name. Per task, fields include `description`, `expected_output`, `agent` (agent name reference), `context` (list of task-name references — **the dependency declaration**), `async_execution`, `output_file`, `output_pydantic` (class name reference), `human_input`, `markdown`, `callback`, `guardrails`.
+
+**Rule 3a-1**: YAML parse errors halt Step 1a per the standard Step 1a §3b.1 policy (frontmatter parse failures are warnings; YAML file parse failures are halts because the file *is* the content).
+
+**Rule 3a-2**: unknown top-level keys (neither an agent name pattern nor a reserved CrewAI config key) are warnings; proceed with detected keys.
+
+### 3b. Cross-reference validation
+
+CrewAI's YAML files reference each other and reference Python code. Melleafy validates at inventory time:
+
+| Reference | Validation |
+|---|---|
+| `tasks.yaml:<task>.agent` → an agent in `agents.yaml` | Warn on unresolved |
+| `tasks.yaml:<task>.context[]` → task names in `tasks.yaml` | Warn on unresolved or cycles |
+| `agents.yaml:<agent>.tools` → `@tool`-decorated functions in `tools.py` | Warn on unresolved |
+| `agents.yaml:<agent>.allowed_agents[]` → agents in `agents.yaml` | Warn on unresolved |
+| `tasks.yaml:<task>.output_pydantic` → a class importable somewhere | Warn on unresolved |
+| `@CrewBase` methods in `crew.py` → entries in YAML files | Warn on mismatch (§2b Rule 2b-1) |
+
+**Rule 3b-1**: unresolved references are warnings, not halts. CrewAI itself often accepts loose references and resolves them at runtime; melleafy mirrors this leniency during inventory and lets Step 7 flag the same issues with file-and-line precision.
+
+### 3c. Python AST parsing
+
+Same machinery as LangGraph (`plans/dialects/langgraph.md` §3b). Relevant patterns for CrewAI:
+
+- `@tool`-decorated functions → C6 source signals
+- `class X(BaseTool)` with `_run` or `run` method → C6 source signals
+- `@CrewBase`, `@agent`, `@task`, `@crew` decorators → cross-references to YAML entries
+- `@start`, `@listen(MethodRef)`, `@router(MethodRef)`, `@persist` decorators → Flow orchestration elements
+- `@human_feedback(emit=[...])` → review-gated modality signal (see §5)
+- `@crewai_event_bus.on(EventType)` → event-triggered modality signal
+- `Agent(...)`, `Task(...)`, `Crew([...])` direct construction calls → alternative to `@CrewBase`
+
+### 3d. Docstrings
+
+Module-level and function docstrings in `tools.py` and `crew.py` are inventoried as C1/C6 content (tool purpose descriptions). Comments (`# ...`) are not, matching LangGraph's §3c rule.
+
+### 3e. `.env` format
+
+Parsed as key=value pairs; values may be quoted or unquoted. Comments (`#`) are skipped. Empty values are preserved as empty strings (distinct from absent). Export statements (`export KEY=value`) are handled — the `export ` prefix is stripped.
+
+---
+
+## 4. Dialect mapping table
+
+| Source signal | Category | Default disposition | Generation target |
+|---|---|---|---|
+| `agents.yaml:<n>.role` | C1 | `bundle` | `config.AGENTS[<n>]` dict; referenced in prompt-assembly |
+| `agents.yaml:<n>.goal` | C1 | `bundle` | Same |
+| `agents.yaml:<n>.backstory` | C1 | `bundle` | Same |
+| `agents.yaml:<n>.llm` | C8 | `bundle` | `config.AGENT_LLMS[<n>]`; SETUP.md §3 documents backend selection |
+| `agents.yaml:<n>.tools[]` | C6 | Inherited from each tool's disposition | `tools.py` or `constrained_slots.py` per tool |
+| `agents.yaml:<n>.memory: true` | C4 | `delegate_to_runtime` | `constrained_slots.py:*_memory`; SETUP.md §4 |
+| `agents.yaml:<n>.allow_delegation: true` | C2 + C6 | *(not reproduced in v1)* | Noted in "Runtime-specific constructs not reproduced" — CrewAI auto-injects delegation tools at runtime |
+| `agents.yaml:<n>.allowed_agents[]` | C2 | `bundle` | `config.ALLOWED_AGENTS` dict; documented in README |
+| `agents.yaml:<n>.max_iter` | C2 | `bundle` | `config.MAX_ITER_<n>` constant |
+| `agents.yaml:<n>.max_rpm` | C8 | `bundle` | Rate-limit config; SETUP.md §3 |
+| `agents.yaml:<n>.reasoning: true` | — | *(informational)* | Noted; affects Step 2 primitive choices for the agent's tasks |
+| `agents.yaml:<n>.multimodal: true` | — | *(not reproduced)* | Listed in "Not reproduced" |
+| `agents.yaml:<n>.system_template` / `prompt_template` / `response_template` | C1 | `bundle` | Prompt templates inlined into `config.PROMPT_TEMPLATES` |
+| `tasks.yaml:<task>.description` | C2 | `bundle` | Inlined into `pipeline.py` as the task's prompt |
+| `tasks.yaml:<task>.expected_output` | C2 | `bundle` | Expected-output text inlined as part of the prompt |
+| `tasks.yaml:<task>.agent` | — | *(structural — not a standalone element)* | Used by Step 2 mapping to attach task to agent |
+| `tasks.yaml:<task>.context[]` | — | `bundle` | Used by Step 2 to generate `ORCHESTRATE` control flow (task dependencies become sequencing in `pipeline.py`) |
+| `tasks.yaml:<task>.output_pydantic` | — | `bundle` | Schema referenced; inlined into `schemas.py` or imported from source |
+| `tasks.yaml:<task>.human_input: true` | C2 + modality | `delegate_to_runtime` | `constrained_slots.py:get_human_input`; drives `review_gated` secondary modality (see §5) |
+| `tasks.yaml:<task>.async_execution: true` | — | `bundle` | `pipeline.py` uses `asyncio` for this task's invocation |
+| `tasks.yaml:<task>.output_file` | — | *(informational)* | Noted; generated pipeline returns the output; user decides file routing |
+| `tasks.yaml:<task>.callback` | C2 | `bundle` if simple, `stub` otherwise | Python callable reference; if resolved in `tools.py` → `real_impl` |
+| `tasks.yaml:<task>.guardrails` | C2 | `bundle` | Each guardrail becomes a `Requirement` entry |
+| `tools.py:@tool`-decorated function | C6 | `real_impl` | `tools.py:<tool_name>` |
+| `tools.py:BaseTool` subclass | C6 | `real_impl` | `tools.py:<tool_name>` wrapped as a function for Mellea compatibility |
+| `tools.py:MCPServerAdapter` usage | C6 | `stub` | `constrained_slots.py:*`; SETUP.md §3 names MCP server |
+| `crew.py:@CrewBase.agents()` / `.tasks()` references | — | *(structural — resolves YAML references)* | Used by mapping; no direct generation target |
+| `crew.py:Process.sequential` (default) | — | `bundle` | Sequential `pipeline.py` orchestration |
+| `crew.py:Process.hierarchical` | C2 + modality | `bundle` with warning | Hierarchical manager pattern — v1 translates to sequential with a "manager" agent as dispatcher |
+| Flow `@start`-decorated method | — | `bundle` | `pipeline.py:run_pipeline` entry point uses the @start method's logic |
+| Flow `@listen(Method)` | — | `bundle` | `pipeline.py` sequential flow: after Method, call this |
+| Flow `@router(Method)` | — | `bundle` | `pipeline.py:if/elif/else` based on router return |
+| Flow `@persist` | C4 | `delegate_to_runtime` | `constrained_slots.py:flow_persist_load` / `flow_persist_save`; SETUP.md §4 |
+| Flow `@human_feedback(emit=[...])` | C2 + modality | `delegate_to_runtime` | `constrained_slots.py:get_human_feedback`; drives `review_gated` modality |
+| `@crewai_event_bus.on(EventType)` | C9 (event_triggered) | `delegate_to_runtime` | `handlers/<event>.py`; SETUP.md §7 |
+| `.env` var entries | C7 | `external_input` | `.env.example` entries |
+| `pyproject.toml:dependencies` | C8 | `bundle` | Merged into generated `pyproject.toml` |
+| `~/Library/Application Support/CrewAI/...` detection | — | *(detection only)* | Noted; contents not inventoried |
+| `CREWAI_STORAGE_DIR` reference in `.env` | C8 | `bundle` | Noted in SETUP.md §4 — user must set if using memory |
+
+**Override semantics.** Default dispositions can be overridden via `--dependencies=ask` or `config:<path>` per the standard R22 contract.
+
+**Rule 4-1**: `allow_delegation: true` is explicitly **not reproduced** in v1. CrewAI's runtime injects "Delegate work to co-worker" and "Ask question to co-worker" tools dynamically at `Crew.kickoff()` time. Melleafy would need to generate these tools statically, which would require knowing the full crew composition at generation time. The `allowed_agents` field restricts targets if delegation is reproduced. For v1, this is a Deferred Item — generated packages warn in their docstring that delegation is not reproduced, and the mapping report surfaces the same.
+
+**Rule 4-2**: `Process.hierarchical` specifies a manager-worker pattern where one agent dispatches tasks to others. v1's translation is approximate — a "manager" helper function in `pipeline.py` that dispatches to worker agents in sequence. This is semantically close but not structurally identical. Mapping report documents the approximation.
+
+---
+
+## 5. Modality signals (Step 0 Axis 5, R21)
+
+CrewAI has the most **declarative** modality signals of any dialect we've covered so far — `tasks.yaml` encodes modality choices as spec-level booleans.
+
+| Signal | Modality classification |
+|---|---|
+| `Crew.kickoff(inputs={...})` call pattern | **`synchronous_oneshot`** — the default |
+| `LLMStreamChunkEvent` via `crewai_event_bus` usage | **`streaming`** (as secondary — event-bus streaming) |
+| `memory=True` on any agent or crew | **`conversational_session`** as secondary (enables cross-session memory) |
+| `tasks.yaml:<task>.human_input: true` | **`review_gated`** as secondary |
+| Flow `@human_feedback(emit=[...])` decorator | **`review_gated`** as secondary (Flows-only variant) |
+| `@crewai_event_bus.on(EventType)` | **`event_triggered`** as primary (if no other invocation pattern present) or secondary |
+| `tasks.yaml:<task>.async_execution: true` | *(behavior — not modality)* — affects generated code shape but not modality classification |
+| Scheduling references (`cron` in spec body) | **`scheduled`** — but CrewAI OSS has no native scheduling (see §6) |
+
+**Rule 5-1**: CrewAI OSS has **no native scheduling**. The CrewAI AMP (Autonomous Multi-Agent Platform) enterprise product offers scheduling; OSS does not. If a spec declares scheduling intent (typically in prose), modality classifies as `scheduled` with `delegate_to_runtime` disposition and SETUP.md §6 names "external cron or AMP" as options.
+
+**Rule 5-2**: `async_execution: true` on a task enables concurrent execution of that task alongside others but does not change the external modality of `Crew.kickoff()`. From outside, the crew is still synchronous. Generated code uses `asyncio` internally for the flagged task; the entry point remains `def run_pipeline(inputs) -> Output`.
+
+**Rule 5-3**: `memory=True` on an agent enables CrewAI's built-in memory system (Chroma-backed). This makes the crew **conversational** across sessions — repeated `kickoff()` calls with the same memory state produce context-aware responses. Modality classification adds `conversational_session` as secondary.
+
+**Rule 5-4**: `human_input: true` on a task is CrewAI's stdin-blocking HITL pattern. Generated code emits a `get_human_input()` stub that reads from stdin; SETUP.md §7 names the host adapter options (web UI, Slack prompt, etc.).
+
+### 5a. Flows modality signals
+
+Flows add their own modality signals:
+
+- `@start`-decorated method → entry point; modality follows the rest of the spec
+- `@human_feedback(emit=[...])` → `review_gated` with a structured emit (channel routing for the feedback request)
+- `@persist` → enables `conversational_session` for the flow's state
+
+**Rule 5a-1**: a Flow with `@human_feedback(emit=["slack", "email"])` declares that the feedback request should route to multiple channels. v1 melleafy doesn't reproduce the emit routing — the stub just receives input from stdin. Mapping report documents the routing declaration as a "Runtime-specific construct not reproduced."
+
+### 5b. Composition common case
+
+The canonical CrewAI modality composition is `synchronous_oneshot + conversational_session + review_gated` — a crew with memory, some tasks marked `human_input`, invoked via `kickoff()`. Primary is `synchronous_oneshot`; secondaries include the others. Generated shape is §5a (synchronous) with stubs for the review-gated tasks.
+
+---
+
+## 6. Quirks and workarounds
+
+### 6a. YAML-to-Python reference resolution
+
+The biggest structural aspect of CrewAI inventory: **agents are declared in YAML but their behavior is shaped by Python code**. An agent's `tools: [calc, search]` references entries in `tools.py`; its `llm:` references a model config that may be in `crew.py` or inferred. Melleafy's cross-reference validation (§3b) catches mismatches at inventory time, but the mapping stage has to bridge YAML declarations with Python implementations.
+
+**Rule 6a-1**: the mapping approach is: each YAML-declared agent becomes a **bundle of config constants** (role, goal, backstory → `config.AGENTS[<n>]`) plus **references to the Python tools** the agent uses. The generated `pipeline.py` assembles these at runtime — it instantiates prompts from config, calls tools from `tools.py`, applies requirements from `requirements.py`. This preserves CrewAI's declarative/executable split semantically.
+
+### 6b. `allow_delegation` is not reproduced (v1)
+
+Per Rule 4-1. This is the biggest single gap in v1's CrewAI support. Delegation means one agent can call another agent as a tool. CrewAI injects these tools at runtime; melleafy would need to generate them statically, requiring full crew-composition knowledge. Deferred.
+
+**Rule 6b-1**: generated packages for specs with `allow_delegation: true` include a docstring warning: "This crew declared `allow_delegation: true`. Inter-agent delegation is not reproduced in v1 — tasks run in the sequence declared in `tasks.yaml:<task>.context`, not with dynamic delegation." Users reviewing can confirm the generated flow matches intent.
+
+### 6c. `@CrewBase` auto-resolution
+
+When `crew.py` uses `@CrewBase`, YAML paths resolve automatically and `load_dotenv()` is called. When it doesn't, everything is explicit. Melleafy generates code that **always explicitly loads `.env`** (via `python-dotenv` in `main.py`) regardless of which source pattern was used. This preserves the runtime behavior for both patterns.
+
+### 6d. Memory backend filesystem paths
+
+CrewAI memory backends use platform-specific paths. Melleafy's generated code uses an **explicit `CREWAI_STORAGE_DIR` env var** rather than the platform-specific defaults — this avoids hidden filesystem dependencies and makes deployment portable. SETUP.md §4 documents the env var; the user sets it to whatever directory suits their deployment.
+
+**Rule 6d-1**: if a spec specifically depends on the platform-default path (e.g., a comment says "memory lives in `~/Library/Application Support/CrewAI`"), the mapping report flags the assumption under "Runtime behaviors preserved" but does not reproduce the platform conditional. v2 could grow platform-aware defaults.
+
+### 6e. Chroma lock file concurrency
+
+CrewAI's Chroma-backed memory uses a single SQLite file per backend. Concurrent writes from parallel crews lock each other out. Melleafy's mapping documents this in SETUP.md §4 and flags in Step 7's category-specific lint — the check is "if the generated package is meant to run as multiple instances, ensure each has a distinct `CREWAI_STORAGE_DIR`."
+
+### 6f. `output_pydantic` is a typed output contract
+
+When a task declares `output_pydantic: SomeClass`, the task's output is validated against that class. This is structurally similar to Mellea's `m.instruct(format=SomeClass)` pattern, and melleafy's mapping uses it directly — the declared Pydantic class is inlined into `schemas.py` and referenced in the task's generated code.
+
+**Rule 6f-1**: the class declared in `output_pydantic` must be importable. If it's defined in a separate file not inventoried (rare), Step 1a warns. If it's defined inline in `crew.py`, it's inventoried as a SCHEMA element.
+
+### 6g. Flow state is typed via generic parameter
+
+`class MyFlow(Flow[StateModel])` uses a generic parameter to declare the state type. `StateModel` is typically a Pydantic model. Melleafy inventories `StateModel` as a SCHEMA element and uses it as the state-passing type in the generated `pipeline.py`. When the generic is `Flow[dict]` (no typed state), melleafy generates a plain `dict` state — less safe but matches source.
+
+### 6h. `Process.hierarchical` translation
+
+Per Rule 4-2. Translated to a sequential pipeline with a "manager" helper function. The translation loses CrewAI's dynamic task-routing behavior (the manager decides at runtime which worker to dispatch); v1 uses a declarative dispatch pattern (manager calls workers in the order declared in `tasks.yaml:context`). Mapping report documents the translation.
+
+### 6i. `@crewai_event_bus.on()` event families
+
+CrewAI's event bus handles many event families: Crew, Agent, Task, Tool, Knowledge, Memory, MCP, LLM, Guardrail, Flow, HITL, A2A, System. v1 melleafy maps any event listener to a handler stub in `handlers/<event_family>.py` with a SETUP.md §7 note. Fine-grained event-specific handling (e.g., distinguishing `CrewKickoffStartedEvent` from `CrewKickoffEndedEvent`) is preserved in the stub signature but the implementation is user-side.
+
+### 6j. CrewAI default flips between versions
+
+CrewAI has had default flips across versions — `allow_delegation` defaulted to True in old versions, now False. `memory` defaulted differently at different points. Melleafy's mapping uses the **current default** (as of 2026-Q1); specs targeting older versions may produce subtle behavior differences. The mapping report notes the current defaults used.
+
+### 6k. MCP via `MCPServerAdapter`
+
+CrewAI integrates MCP via `MCPServerAdapter`. The adapter takes a server config and exposes the server's tools. Melleafy stubs MCP tools in `constrained_slots.py` because MCP servers are external processes the generated package doesn't manage. SETUP.md §3 names the MCP server and documents how the user wires it.
+
+### 6l. No native scheduling in OSS
+
+Per Rule 5-1. `scheduled` modality for CrewAI implies external cron or the AMP enterprise product. SETUP.md §6 documents both options.
+
+---
+
+## 7. Reference inventory output (illustrative)
+
+For a minimal CrewAI spec — `config/agents.yaml` with one agent, `config/tasks.yaml` with two tasks (one with `human_input`), `tools.py` with one tool, and `crew.py` with `@CrewBase`:
+
+### Inventory (abridged)
+
+```json
+{
+  "elements": [
+    {"element_id": "elem_001", "source_file": "config/agents.yaml", "source_lines": "yaml:researcher.role", "tag": "CONFIG", "category": "C1", "content_summary": "Agent 'researcher': role = Senior researcher"},
+    {"element_id": "elem_002", "source_file": "config/agents.yaml", "source_lines": "yaml:researcher.backstory", "tag": "CONFIG", "category": "C1", "content_summary": "Agent 'researcher': backstory (3 paragraphs)"},
+    {"element_id": "elem_003", "source_file": "config/agents.yaml", "source_lines": "yaml:researcher.tools", "tag": "TOOL_TEMPLATE", "category": "C6", "content_summary": "Agent 'researcher' uses tools: [search, calc]"},
+    {"element_id": "elem_010", "source_file": "config/tasks.yaml", "source_lines": "yaml:extract_claims.description", "tag": "EXTRACT", "category": "C2", "content_summary": "Task 'extract_claims': extract key claims from input"},
+    {"element_id": "elem_011", "source_file": "config/tasks.yaml", "source_lines": "yaml:review_claims.human_input", "tag": "CONVERSE", "category": "C2", "content_summary": "Task 'review_claims' requires human approval"},
+    {"element_id": "elem_020", "source_file": "tools.py", "source_lines": "py:tools.py:5-20", "tag": "TOOL_TEMPLATE", "category": "C6", "content_summary": "@tool search: DuckDuckGo web search"},
+    {"element_id": "elem_030", "source_file": "crew.py", "source_lines": "py:crew.py:10-40", "tag": "ORCHESTRATE", "category": "—", "content_summary": "@CrewBase class with sequential process"}
+  ]
+}
+```
+
+Note `source_lines` formats: `yaml:<dotted-path>` for YAML references, `py:<file>:<range>` for Python (matching LangGraph's convention). Four source_lines conventions are now in use across dialects — `line_range`, `frontmatter.<field>`, `json:<path>`, and now `yaml:<path>`.
+
+### Element mapping (abridged)
+
+```json
+{
+  "mappings": [
+    {"element_id": "elem_001", "target_file": "config.py", "target_symbol": "AGENTS['researcher']['role']", "primitive": "bundle"},
+    {"element_id": "elem_002", "target_file": "config.py", "target_symbol": "AGENTS['researcher']['backstory']", "primitive": "bundle"},
+    {"element_id": "elem_003", "target_file": "pipeline.py", "target_symbol": "_researcher_tools", "primitive": "reference"},
+    {"element_id": "elem_010", "target_file": "pipeline.py", "target_symbol": "_task_extract_claims", "primitive": "@generative"},
+    {"element_id": "elem_011", "target_file": "constrained_slots.py", "target_symbol": "get_human_input_review_claims", "primitive": "stub"},
+    {"element_id": "elem_020", "target_file": "tools.py", "target_symbol": "search", "primitive": "real_impl"},
+    {"element_id": "elem_030", "target_file": "pipeline.py", "target_symbol": "run_pipeline", "primitive": "orchestrate"}
+  ]
+}
+```
+
+### Dialect-specific notes in the mapping report
+
+- A "YAML-Python reference resolution" section confirming cross-references (YAML tool names → `tools.py` implementations, task→agent bindings, etc.).
+- A "Runtime-specific constructs not reproduced" section listing `allow_delegation`, `multimodal`, `@human_feedback emit` routing, Process.hierarchical manager pattern (if translated).
+- A "CrewAI sub-variant" note: "crew_only" / "flow_only" / "crew_and_flow" (§2c Rule 2c-2).
+- A "Default version flip awareness" callout noting which CrewAI defaults were used (§6j).
+
+---
+
+## 8. Deferred CrewAI features (not handled in v1)
+
+- **Inter-agent delegation** via `allow_delegation: true` — v1 doesn't reproduce runtime tool injection. Users with delegation-heavy crews should manually wire the generated code.
+- **`Process.hierarchical` full semantics** — v1 translates to sequential with a "manager" helper. Dynamic task routing is lost.
+- **Native scheduling (AMP feature)** — v1 stubs; SETUP.md §6 documents options.
+- **Multimodal agents** (`multimodal: true`) — v1 generates text-only pipelines.
+- **Flow `@human_feedback emit` channel routing** — v1 ignores routing; stubs receive from stdin.
+- **Event-bus event-family-specific handlers** — v1 handles generically; specific events (e.g., `CrewKickoffStartedEvent` vs `...EndedEvent`) are differentiated in stub signatures but not in behavior.
+- **`MCPServerAdapter` full integration** — v1 stubs MCP tools; user wires the server externally.
+- **Chroma memory bundling** — v1 never bundles memory state; user's deployment recreates memory on first run.
+- **Platform-default memory paths** — v1 requires explicit `CREWAI_STORAGE_DIR`; platform-specific defaults not reproduced.
+- **Training data handling** (`Crew.train()` is a CrewAI feature for optimising prompts over examples) — v1 doesn't reproduce; user uses base prompts.
+- **Knowledge sources** declared via `Knowledge` class — inventoried but treated as C5 delegate; not bundled.
+
+---
+
+## 9. Cross-references
+
+- `spec.md` R1, R21, R22 — the contracts this dialect implements
+- `plans/dialects/openclaw.md` — template; file-inventory pattern
+- `plans/dialects/langgraph.md` — Python AST handling; `py:` source_lines format
+- `plans/dialects/letta.md` — structured-content patterns (JSON analog to YAML)
+- `plans/dialects/claude-code.md` — Markdown workspace patterns for reference
+- `plans/generated-package-shape.md` — shape of the generated output
+- `glossary.md` — `dialect`, `disposition`, `interaction modality`
+- `melleafy.json` schema — the manifest fields this dialect populates
+
+---
+
+## 10. Ratification notes
+
+This dialect doc v1.0.0 was the sixth drafted, selected to complete the set of file-based dialects before tackling the remaining pure-code dialects (AutoGen, OpenAI Agents SDK, smolagents).
+
+**What the template survived unchanged:**
+- Section 1 (Detection signals) — the signal-count model accommodates CrewAI's mix of YAML and Python signals without restructure.
+- Section 4 (Dialect mapping table) — the longest we've produced (about 40 rows), but the four-column shape held.
+- Sections 5, 6, 7, 8, 9 — translated directly.
+
+**What the template needed to adapt:**
+- **Section 2 (File inventory)** — became genuinely dual-surface: Section 2a for YAML (declarative) plus Section 2b for Python (executable). The template already supports "multiple sub-sections per section" so this was natural; Letta had one structured-data section, Claude Code had multiple file types, LangGraph had one declarative + one code surface, and CrewAI has both.
+- **Section 2c (Flows as higher-order layer)** — a new sub-section shape for runtime polymorphism within one dialect. Flows are optional and compose over crews; the template accommodated by treating them as their own Section 2 sub-section.
+- **Section 3 (Structured-content rules)** — YAML parsing section uses the same shape as Letta's §3a (JSON parsing) and Claude Code's §3a (JSON parsing); proves YAML and JSON are interchangeable at this level of abstraction.
+- **Section 6 (Quirks)** — grew to twelve sub-sections (6a–6l) because CrewAI has the most distinct runtime behaviors to document. The template's Quirks section has no fixed size; this was fine.
+- **§7 `source_lines` convention** introduces `yaml:<dotted-path>` as a fourth format. The proliferation continues; the plan is still to formalise all four as `source_range: {format, value}` in Step 1b.
+
+**Runtime polymorphism observation.** CrewAI is the first dialect where a single spec can use different architectural patterns — crew-only, flow-only, or crew+flow. Each variant is a valid CrewAI spec; melleafy records which variant applies in the mapping report. This is worth flagging for other dialects that might have similar polymorphism (AutoGen has OSS vs AGS; OpenAI Agents SDK has plain vs Swarm vs SandboxAgent).
+
+Open questions:
+
+- **§6b `allow_delegation` not reproduced** is the biggest single gap. For CrewAI users relying on delegation, v1 generates sequential code that loses the dynamic routing. Worth corpus-testing how common delegation-heavy crews are in real specs.
+- **§6h `Process.hierarchical` translation to sequential** loses dynamic dispatch. A user whose spec explicitly needs manager-style routing would find the v1 translation inadequate. Consider a dedicated "hierarchical-pattern preservation" option in v2.
+- **§6j default-flip awareness** notes CrewAI's defaults have changed across versions. Worth a `--crewai-version=<v>` override flag for specs targeting older CrewAI; v1 uses current defaults.
+- **§5b composition** is opinionated about which modality is primary vs secondary. A spec with `human_input: true` on every task arguably has `review_gated` as primary. Worth tuning with corpus data.
+- **§2b Rule 2b-1 auto-resolution vs explicit construction** — melleafy treats both patterns identically, but the generated code could in principle match the source pattern more faithfully (e.g., using `@CrewBase`-style resolution in generated code if the source used it). v1 chose uniform output shape; v2 could add a preservation option.
+- **Flow `@persist` state semantics** — CrewAI's Flow persistence uses Pydantic models serialised to specific backend locations. v1's stub-based handling is generic; richer support is a v2 concern.
+- **Cross-reference validation at inventory time** (§3b) is warn-only. Worth considering whether unresolved `agent:` references in `tasks.yaml` should halt, since they represent broken specs. Argument for halt: clearer user feedback. Argument against: CrewAI itself is lenient. Sticking with warn for v1.

--- a/docs/dialects/hybrid.md
+++ b/docs/dialects/hybrid.md
@@ -1,0 +1,412 @@
+# Hybrid Dialect
+
+**Version**: 1.0.0
+**Status**: Seventh dialect doc, but distinct in kind. Where the other dialects describe specific source runtimes, Hybrid is a **classification outcome** that triggers when two or more dialects' signals tie. It's a meta-dialect: a procedure for composing other dialects' rules rather than a runtime of its own. The 10-section template partly fits and partly requires explicit adaptation.
+
+**Prerequisite reading**: `spec.md` R1 (detection — especially the Hybrid threshold rule and the 1-signal-difference semantics), R22 (dialect mapping contract); all the runtime-specific dialect docs under `plans/dialects/` for per-runtime rules; `plans/steps/step-0-classification.md` §6 (source runtime detection); `plans/steps/step-1a-inventory.md`, `plans/steps/step-1b-tagging.md`, `plans/steps/step-2-mapping.md`, `plans/steps/step-2.5-dependencies.md`.
+
+---
+
+## What this document does
+
+Describes what melleafy does when a spec's source-runtime classification outcome is `hybrid`. Hybrid classification happens when two or more supported runtimes have signal counts within 1 of each other after Step 0's detection pass (per R1 Hybrid threshold). This doc is the **reference for how multiple dialect rule sets combine** during Steps 1a, 1b, 2, 2.5, and 5.
+
+Unlike the other dialect docs, Hybrid has:
+
+- No unique detection signals of its own (§1 is about the *classification path* to Hybrid, not signals)
+- No file inventory rules of its own (§2 describes how contributing runtimes' rules are merged)
+- No frontmatter rules of its own (§3 same)
+- No mapping rows of its own (§4 describes conflict resolution between contributing runtimes' rows)
+- A composition-specific modality handling (§5)
+
+Hybrid is a **meta-procedure**, not a runtime description.
+
+Key concepts readers should have in mind:
+
+- **Primary runtime**: the contributing runtime with the highest signal count among ties. If signal counts are exactly equal, R1's tiebreak list decides: Agent Skills std > Claude Code > OpenClaw > CrewAI > LangGraph > AutoGen > Letta > Agents SDK > smolagents.
+- **Contributing runtime(s)**: all other runtimes whose signals were within 1 of the primary.
+- **Conflict**: when two contributing runtimes' rules disagree about a specific source signal — different category, different disposition, or different target file.
+- **Composition**: the process of applying multiple dialects' rules and merging their outputs into a single inventory / mapping / plan.
+
+---
+
+## 1. The path to Hybrid classification
+
+No signals fire Hybrid directly. Hybrid is what Step 0 produces when:
+
+- The winning runtime's signal count is within 1 of the second-place runtime's signal count, AND
+- Neither runtime is `unknown` (zero signals matched), AND
+- The user has not passed `--source-runtime <specific-runtime>` to override detection.
+
+**Rule 1-1**: Hybrid can involve two or more contributing runtimes. The within-1 threshold applies pairwise between the primary and each would-be contributor. Example: if OpenClaw has 8 signals, Claude Code has 7, and Letta has 6 signals, the primary is OpenClaw, Claude Code is a contributor (within 1 of 8), and Letta is not (within 2 of 8, outside threshold) — so the hybrid is OpenClaw + Claude Code, not OpenClaw + Claude Code + Letta.
+
+**Rule 1-2**: the within-1 threshold uses **weighted signal counts** per `plans/steps/step-0-classification.md` §6b (strong=2, medium=1, weak=0.5). Not raw signal counts.
+
+**Rule 1-3**: `--source-runtime=hybrid` is a valid CLI argument and forces Hybrid classification regardless of detection. In this case, melleafy asks the user to declare which runtimes are contributing (via an interactive prompt or a `--contributing-runtimes=a,b,c` flag). Without contributing-runtime information, Hybrid classification cannot proceed — there are no dialect rules to merge.
+
+### 1a. Common hybrid pairings
+
+Observed in practice:
+
+| Pairing | Typical scenario |
+|---|---|
+| Claude Code + OpenClaw | Project uses Claude Code as dev environment, targets OpenClaw at runtime |
+| Claude Code + Letta | Letta agent with a Claude Code wrapper for development |
+| CrewAI + LangGraph | Flows composing over LangGraph subgraphs, or the reverse |
+| Agent Skills std + Claude Code | Edge case where `.claude/` exists as artifact from previous iteration but frontmatter is Agent-Skills-only |
+| OpenClaw + Letta | Memory-heavy spec targeting either runtime; signals overlap on heartbeat + memory |
+
+**Rule 1a-1**: rare but possible: three-way hybrids (e.g., Claude Code + OpenClaw + Letta). The composition rules in this doc scale to N contributors, but the user experience degrades — elicitation prompts per-entry grow linearly with contributor count. The mapping report warns when N ≥ 3.
+
+### 1b. What Hybrid classification records in `classification.json`
+
+Step 0 produces a `classification.json` with:
+
+```json
+{
+  "source_runtime": "hybrid",
+  "source_runtime_override": null,
+  "hybrid_threshold_triggered": true,
+  "hybrid_primary": "openclaw",
+  "hybrid_contributors": ["claude_code"],
+  "source_runtime_scores": {"openclaw": 8, "claude_code": 7, "letta": 6, ...},
+  "source_runtime_signals": { ... full signal table per runtime ... }
+}
+```
+
+The `hybrid_primary` and `hybrid_contributors` fields are unique to Hybrid classifications. They drive every composition decision in Steps 1a, 1b, 2, 2.5, and 5.
+
+---
+
+## 2. File inventory composition (Step 1a)
+
+Step 1a's job for a Hybrid spec is: apply **all contributing runtimes' file inventory rules** and merge the results into one file list.
+
+### 2a. Per-runtime inventory pass
+
+For each contributing runtime (primary + all contributors), Step 1a runs its normal inventory pass per that runtime's dialect doc §2. The outputs are merged.
+
+**Rule 2a-1**: the workspace root is determined by the **primary runtime's Section 2** rules. For OpenClaw the workspace is the spec's parent directory; for Claude Code it's the first ancestor containing `.claude/` or `.git/`. If primary is OpenClaw, OpenClaw's workspace rule applies even when Claude Code is a contributor.
+
+**Rule 2a-2**: contributing runtimes' inventory passes **do not change the workspace root** — they scan the primary's workspace for their own file patterns. A Claude Code `.claude/settings.json` found inside an OpenClaw workspace is inventoried per Claude Code's rules.
+
+**Rule 2a-3**: files unique to one contributing runtime are added to the file list with `dialect_rule_id` pointing at that runtime's dialect doc. A `SOUL.md` inventoried under OpenClaw's rules and a `settings.json` inventoried under Claude Code's rules appear as siblings in the file list.
+
+### 2b. Overlap handling
+
+When the same file is inventoried by two contributing runtimes (rare but possible — e.g., a `README.md` or a `.env` file might be handled similarly by multiple dialects):
+
+**Rule 2b-1**: the file appears exactly once in the file list, with `dialect_rule_id` being an array of all matching rule IDs, and `role` being a combined role string.
+
+**Rule 2b-2**: when two runtimes assign *incompatible* roles to the same file (e.g., OpenClaw says "C2 operating rules" but Letta says "C3 user context" — implausible but illustrative), the primary runtime's role wins and the contributor's role is recorded in the inventory report as `conflicting_roles` metadata.
+
+### 2c. Credential-location handling
+
+Multiple runtimes may declare different credential conventions. Step 1a records each credential reference from each runtime's rules:
+
+- Claude Code's `.claude/.credentials.json` or macOS Keychain references
+- OpenClaw's `~/.openclaw/.env` and `~/.openclaw/credentials/`
+- Letta's server env vars (`LETTA_PG_URI`, etc.)
+- CrewAI's project `.env`
+- LangGraph's `langgraph.json:env`
+
+**Rule 2c-1**: credentials are **detection-only** (contents never read) regardless of which runtime's rules applied. Each credential location referenced across contributing runtimes is noted in the inventory report; SETUP.md §2 in the generated package enumerates all of them so the user can configure any one.
+
+### 2d. Missing-file semantics
+
+When a file is expected-but-absent per one runtime's rules and absent-as-expected per another:
+
+**Rule 2d-1**: "expected" wins over "optional." If OpenClaw's rules say SOUL.md is optional but Claude Code's rules say SKILL.md is required, SKILL.md's absence takes precedence as the concerning one. The inventory report records both.
+
+**Rule 2d-2**: files absent under all contributing runtimes' rules are simply not present; no note in the report.
+
+### 2e. Cross-runtime file references
+
+Some files referenced by one runtime's rules may exist as artifacts of another runtime's system. Example: a `.claude/settings.json:mcpServers` declaration references an MCP server that a Letta spec also declares via `tools[].source_code`. Both runtimes' rules treat this as a C6 element but with different target files.
+
+**Rule 2e-1**: cross-runtime references are resolved **deferred to Step 2** — inventory just records each reference as-seen per its own runtime's rules. Step 2's mapping phase sees both references and marks them as a "Hybrid conflict" entry that Step 2.5's elicitation surfaces.
+
+---
+
+## 3. Structured-content rules composition
+
+Each contributing runtime has its own structured-content rules (Section 3 in its dialect doc). For Hybrid specs, all contributing runtimes' rules apply to their own files.
+
+### 3a. Per-runtime parsing
+
+When Step 1a reads a file inventoried under Claude Code's rules, Claude Code's frontmatter/JSON parsing applies. When it reads a file inventoried under OpenClaw's rules, OpenClaw's parsing applies. There's no cross-pollination — each file is parsed per the rules that inventoried it.
+
+**Rule 3a-1**: a file that was inventoried under two runtimes simultaneously (§2b overlap case) uses the primary runtime's parsing rules.
+
+### 3b. Content-type conflicts
+
+Rare but possible: a file named `SKILL.md` might contain Markdown content that could be interpreted per Claude Code's rules or per Agent Skills std's strict allow-list. When the primary runtime's frontmatter rules would accept fields that the contributing runtime's rules reject (or vice versa), the primary runtime's rules apply.
+
+**Rule 3b-1**: frontmatter fields that are valid under the primary runtime but rejected by the contributor's rules don't produce errors — they produce a warning in the inventory report noting the contributor would reject them.
+
+---
+
+## 4. Mapping-table composition (Step 2)
+
+Step 2's mapping phase receives the merged inventory from Step 1a and must produce a single `element_mapping.json`. When the same source signal could be mapped per multiple contributing runtimes' rules, the composition logic kicks in.
+
+### 4a. Mapping table application order
+
+For each element in the inventory:
+
+1. Check the element's `dialect_rule_id` to see which runtime(s) claimed it during inventory.
+2. If claimed by only one runtime, apply that runtime's Section 4 mapping rules.
+3. If claimed by multiple runtimes, attempt each runtime's mapping rules:
+   - If all runtimes map the element to the same category + disposition + target file, use that mapping (no conflict).
+   - If any of the three differs, flag as a **Hybrid conflict**.
+
+### 4b. Hybrid conflict resolution
+
+A conflict is any case where two contributing runtimes' mapping rules disagree on category, disposition, or target file for the same element.
+
+**Rule 4b-1**: default resolution is "**primary wins**" — the primary runtime's mapping row applies, and the conflict is recorded in `element_mapping_judgment_calls.json` with `conflict_type: "hybrid"` and the alternative mapping(s) noted.
+
+**Rule 4b-2**: Step 2.5 elicitation (in `ask` mode) surfaces Hybrid conflicts as high-priority items. The user sees:
+
+```
+[Hybrid conflict] elem_042: tool_ref to GitHub API
+  Primary (Claude Code) says: C6 Tools → real_impl → tools.py:github_fetch
+  Contributor (OpenClaw) says: C6 Tools → real_impl → tools.py:github_fetch + C7 credential GITHUB_TOKEN
+  
+  [p]rimary wins   [c]ontributor wins   [m]erge   [d]etail   [s]kip
+  ›
+```
+
+**Rule 4b-3**: the "merge" option combines both runtimes' outputs (e.g., in the example above, produce both the tool and the credential entry). Merge is valid only when the conflict is about *additions* rather than *contradictions*. If one runtime says "bundle" and another says "stub" for the same signal, merge is not offered.
+
+**Rule 4b-4**: in `auto` mode, "primary wins" is applied silently, and the mapping report surfaces every conflict prominently under a "Hybrid conflicts auto-resolved" section.
+
+### 4c. Elements unique to one contributor
+
+Elements that exist only per one contributing runtime's rules (no overlap with the primary's view) are mapped using **only that contributor's rules**. The primary's mapping table doesn't apply because it didn't see the element at inventory time.
+
+### 4d. Shared elements — merged metadata
+
+Sometimes both runtimes see the same element but each contributes distinct metadata. Example: both Claude Code and OpenClaw might see an `allowed-tools` entry referencing GitHub, but Claude Code adds a `WebFetch(domain:*.github.com)` network constraint while OpenClaw adds a `~/.openclaw/credentials/github.token` credential reference.
+
+**Rule 4d-1**: when two runtimes see the same source signal with non-conflicting metadata, the element's `metadata` field merges both. The mapping preserves the fuller picture.
+
+### 4e. Target-file conflicts
+
+A rare but important case: two runtimes might both want to route an element to the same target file but with different symbol names. E.g., Claude Code's MCP-tool rule maps to `constrained_slots.py:<server>_<tool>`, while Letta's tool rule maps the same conceptual tool to `tools.py:<tool>`. Both target files exist in the generated package; the conflict is which file should contain the implementation.
+
+**Rule 4e-1**: target-file conflicts follow the "primary wins" default unless the element's disposition differs — if Claude Code says `stub` and Letta says `real_impl`, the stub wins (defensive — the tool may not work without the runtime's native integration).
+
+---
+
+## 5. Modality signals composition (Step 0 Axis 5)
+
+Modality detection for Hybrid specs runs both contributing runtimes' Pass 1 (explicit signals) and merges results.
+
+### 5a. Explicit signals union
+
+Each contributing runtime's explicit modality signals are evaluated. The results:
+
+- If primary and contributor agree (same modality), that modality wins.
+- If they produce different modalities, the primary wins as **primary modality** and the contributor's modality is added to `secondary_modalities`.
+
+**Rule 5a-1**: if the contributor's modality would be host-needing (`review_gated`, `scheduled`, `event_triggered`, `heartbeat`, `realtime_media`) while the primary's is Mellea-native, the combination is recorded as "primary with secondary host-adapter requirement." SETUP.md §5/§6/§7 in the generated package names the secondary.
+
+### 5b. Common composition patterns
+
+Common pairings and their modality outcomes:
+
+| Primary | Contributor | Primary modality | Secondary modality | Notes |
+|---|---|---|---|---|
+| OpenClaw | Claude Code | `heartbeat` (if declared) | — | Claude Code adds no runtime-specific modality signals beyond OpenClaw's |
+| Claude Code | OpenClaw | Inferred from Claude Code | `heartbeat` (if OpenClaw declares) | OpenClaw's `openclaw.json:heartbeat.every` adds heartbeat as secondary |
+| CrewAI | LangGraph | Per CrewAI rules | `review_gated` or others per LangGraph | Both have their own modality signals |
+| Letta | Claude Code | Per Letta rules | — | Claude Code rarely adds modality beyond Letta's explicit signals |
+| Agent Skills std | Claude Code | (Edge case — shouldn't happen; see §6) | — | — |
+
+**Rule 5b-1**: Pass 2 (LLM inference) runs only if **neither** contributing runtime has any explicit modality signals. This is rare for Hybrid classifications (if one runtime has explicit signals, use them).
+
+### 5c. Composition validation
+
+The standard R21 composition validation (`plans/steps/step-0-classification.md` §7c) applies. Specifically:
+
+- `realtime_media` + `batch` is still impossible regardless of Hybrid status.
+- `scheduled + review_gated` is still awkward.
+- Any composition producing `unknown` in secondary is still a schema error.
+
+**Rule 5c-1**: composition rules apply to the *merged* modality set, not per-runtime. If the primary's `conversational_session` and a contributor's `review_gated` together make a valid composition (they do — it's the LangGraph HITL canonical pattern), the composition is accepted.
+
+---
+
+## 6. Known edge cases
+
+### 6a. Agent Skills std + Claude Code
+
+This pairing is an edge case because Claude Code is a **strict superset** of Agent Skills std — if both sets of signals match, Claude Code should elevate and Hybrid shouldn't trigger. In practice, the signal-count can tie if:
+
+- The spec has only Agent-Skills-std-compliant frontmatter (no Claude Code extensions)
+- The workspace has a `.claude/` directory (maybe from a previous iteration or accidentally included)
+
+**Rule 6a-1**: when Agent Skills std + Claude Code would produce a Hybrid classification, melleafy **promotes to Claude Code** (not Hybrid). The rationale: Claude Code's rules accept Agent Skills std frontmatter (it's a superset), so treating the spec as Claude Code loses no information; treating as Hybrid would split inventory across two rule sets needlessly.
+
+**Rule 6a-2**: this is the one hybrid pairing that doesn't produce a Hybrid outcome. Every other pairing proceeds normally.
+
+### 6b. Code-first + code-first
+
+Hybrid between two code-first runtimes (e.g., LangGraph + AutoGen) is unusual but possible. AST pattern discovery runs both sets of patterns on each Python file. Elements matching patterns from both runtimes are flagged as shared; elements matching only one are attributed to that runtime.
+
+**Rule 6b-1**: cross-framework Python imports are signals — a file that imports from both `langgraph` and `autogen_agentchat` is likely a bridge file mixing both runtimes. Flagged prominently in the mapping report.
+
+### 6c. Three-way Hybrids
+
+Per Rule 1a-1, three-way Hybrids are rare but possible. Composition scales:
+
+- Inventory runs all three passes and merges.
+- Mapping uses three-way conflict resolution (primary > contributor 1 > contributor 2 precedence).
+- Modality composition may produce up to three secondary modalities.
+
+**Rule 6c-1**: the mapping report's Classification section includes a prominent warning: "Three contributing runtimes detected. Review Hybrid conflicts carefully; consider whether this is the intended source spec shape."
+
+### 6d. Hybrid + `--source-runtime` override
+
+`--source-runtime <specific-runtime>` overrides detection. When applied to a spec that would otherwise have been Hybrid, the specific runtime becomes primary and **no contributing runtimes apply** — the override collapses the composition to a single dialect. Elements that would have been attributed to contributors are now either:
+
+- Inventoried per the specified runtime (if its rules match), or
+- Not inventoried at all.
+
+**Rule 6d-1**: the override causes a warning in the mapping report: "Source was detected as Hybrid ({primary} + {contributors}); overridden to {specified runtime}. Elements unique to {contributors} may be missed."
+
+### 6e. Workspace-root ambiguity
+
+Different runtimes have different workspace-root rules:
+
+- OpenClaw: spec's parent directory
+- Claude Code: first ancestor with `.claude/` or `.git/`
+- CrewAI: spec's parent directory (`config/` is a sibling)
+
+When contributing runtimes would produce different workspace roots, the primary wins (Rule 2a-1). The inventory report notes which rule determined the root.
+
+### 6f. Melleafy.json manifest handling
+
+The generated package's `melleafy.json` records Hybrid classification:
+
+```json
+{
+  "source_runtime": "hybrid",
+  "hybrid_primary": "openclaw",
+  "hybrid_contributors": ["claude_code"],
+  "target_runtime": "mellea",
+  ...
+}
+```
+
+**Rule 6f-1**: downstream consumers of `melleafy.json` (the v2 `melleafy export --host=<n>` tool, for instance) can use `hybrid_primary` as the canonical source for host-adapter generation. This preserves the primary's semantics without requiring the adapter tool to understand all contributing runtimes.
+
+---
+
+## 7. Reference inventory output (illustrative)
+
+For an OpenClaw + Claude Code Hybrid spec — OpenClaw workspace with SOUL.md, AGENTS.md, plus a `.claude/settings.json`:
+
+### Classification outcome
+
+```json
+{
+  "source_runtime": "hybrid",
+  "hybrid_primary": "openclaw",
+  "hybrid_contributors": ["claude_code"],
+  "source_runtime_scores": {"openclaw": 8, "claude_code": 7, "letta": 1, ...}
+}
+```
+
+### Inventory (abridged)
+
+```json
+{
+  "elements": [
+    {"element_id": "elem_001", "source_file": "SOUL.md", "source_lines": "1-40", "tag": "CONFIG", "category": "C1", "content_summary": "Persona — research assistant", "dialect_rule_id": "openclaw:2a:soul_md"},
+    {"element_id": "elem_010", "source_file": "AGENTS.md", "source_lines": "10-25", "tag": "ORCHESTRATE", "category": "C2", "content_summary": "Workflow: extract → summarize → cite", "dialect_rule_id": "openclaw:2a:agents_md"},
+    {"element_id": "elem_030", "source_file": ".claude/settings.json", "source_lines": "json:permissions.deny[0]", "tag": "VALIDATE_OUTPUT", "category": "C2", "content_summary": "Never run rm -rf", "dialect_rule_id": "claude_code:2c:settings_json"},
+    {"element_id": "elem_031", "source_file": ".claude/settings.json", "source_lines": "json:hooks.PreToolUse[0]", "tag": "ORCHESTRATE", "category": "C9", "content_summary": "PreToolUse hook: log every tool call", "dialect_rule_id": "claude_code:2c:settings_json"}
+  ]
+}
+```
+
+### Element mapping (abridged, showing a conflict)
+
+```json
+{
+  "mappings": [
+    {"element_id": "elem_001", "target_file": "config.py", "target_symbol": "PREFIX_TEXT", "primitive": "bundle"},
+    {"element_id": "elem_010", "target_file": "pipeline.py", "target_symbol": "run_pipeline", "primitive": "orchestrate"},
+    {"element_id": "elem_030", "target_file": "requirements.py", "target_symbol": "OPERATING_REQUIREMENTS", "primitive": "requirement", "dialect_override_applied": "claude_code"},
+    {"element_id": "elem_031", "target_file": "handlers/pre_tool_use.py", "target_symbol": "handle_pre_tool_use", "primitive": "delegate", "conflict": {"type": "hybrid", "alternative": {"runtime": "openclaw", "target_file": "constrained_slots.py", "reason": "OpenClaw has no PreToolUse equivalent"}, "resolution": "contributor_only"}}
+  ]
+}
+```
+
+### Dialect-specific notes in the mapping report
+
+A Hybrid classification produces these distinctive sections in the mapping report:
+
+- **Classification** section: "Hybrid classification: primary = OpenClaw (score 8), contributor = Claude Code (score 7). Processing applied both rule sets."
+- **Hybrid conflicts auto-resolved** (for `auto` mode) OR **Hybrid conflicts surfaced for user review** (for `ask` mode): each conflict with resolution.
+- **Contributions by runtime**: which elements came from which runtime's rules. Useful for users reviewing to confirm every source surface was read.
+- **Missing-under-primary, present-under-contributor** notes: where a contributor's rules added elements the primary's rules would have missed.
+
+---
+
+## 8. Deferred Hybrid features (not handled in v1)
+
+- **Three-way-plus Hybrids with complex conflicts** (§6c) — v1 handles them but the user experience degrades with conflict volume. v2 could add conflict-batching or summarisation.
+- **Explicit hybrid-rule authoring** — users cannot author custom composition rules in v1. The rules are always "primary wins with contributor augmentation." If users want different semantics, they override via `--source-runtime` to collapse.
+- **Hybrid-specific SETUP.md templates** — v1 assembles SETUP.md from the primary's template with contributor additions. Richer per-hybrid templates (e.g., "how to deploy an OpenClaw + Claude Code hybrid") are deferred.
+- **Conflict machine-learnability** — v1's conflict resolution is rule-based. v2 could learn patterns from user elicitation choices and suggest resolutions for similar future conflicts.
+- **Cross-runtime element aggregation** — v1 aggregates only within a single runtime's rules. If the same semantic rule is expressed both as an OpenClaw AGENTS.md line and a Claude Code settings.json `permissions.deny[]` entry, v1 records both; aggregating them as a single element is deferred.
+
+---
+
+## 9. Cross-references
+
+- `spec.md` R1 (detection precedence + Hybrid threshold), R22 (dialect mapping contract)
+- All individual dialect docs under `plans/dialects/`: OpenClaw, Claude Code, Letta, Agent Skills std, LangGraph, CrewAI (and future: AutoGen, OpenAI Agents SDK, smolagents)
+- `plans/steps/step-0-classification.md` §6 (source runtime detection — including Hybrid rules)
+- `plans/steps/step-1a-inventory.md` — base file inventory procedure
+- `plans/steps/step-1b-tagging.md` — base tagging procedure
+- `plans/steps/step-2-mapping.md` §4 (dialect overrides)
+- `plans/steps/step-2.5-dependencies.md` §3 (elicitation in `ask` mode — where conflicts surface)
+- `plans/steps/step-5-artifacts.md` §1a (mapping report structure)
+
+---
+
+## 10. Ratification notes
+
+This dialect doc v1.0.0 was the seventh drafted, and it's unusual in kind. The other six describe specific source runtimes with detection signals, file inventories, frontmatter rules, and mapping tables. Hybrid has none of those in itself — it's a composition procedure for when two (or more) other runtimes' signals tie.
+
+**How much of the template fit:**
+
+- Section 1 (Detection signals) — **partial fit**. No signals unique to Hybrid; instead this section describes the classification path to Hybrid and the composition's own metadata (primary, contributors).
+- Section 2 (File inventory rules) — **partial fit**. No rules of its own; instead describes how contributing runtimes' rules merge. Section retained but content is all about composition.
+- Section 3 (Structured-content rules) — **partial fit**. No rules of its own; parsing delegates to each contributor's rules.
+- Section 4 (Dialect mapping table) — **reshaped**. No mapping rows; instead describes conflict resolution between contributors' rows. The section is about *meta-mapping*, not about mapping.
+- Section 5 (Modality signals) — **partial fit**. No signals of its own; composition rules instead.
+- Section 6 (Quirks and workarounds) — **fits naturally**. Becomes "Known edge cases for Hybrid."
+- Section 7 (Reference inventory output) — **fits**. Shows an example Hybrid classification and mapping.
+- Sections 8, 9, 10 — **fit naturally**. No adaptation needed.
+
+**What this tells us about template generality.** Hybrid stretches the template — about half the sections needed content-reshaping rather than content-filling — but the 10-section skeleton held. The template assumes "this doc describes a source runtime"; Hybrid isn't really a source runtime, so sections 1-5 became meta-descriptions. A reader skimming the section headers sees familiar structure (Detection, Inventory, Frontmatter, Mapping, Modality), and the content within each makes sense as "how Hybrid handles this concern."
+
+The alternative — inventing a new section structure just for Hybrid — would have been worse. It would have reduced cross-doc consistency and forced readers to learn a second layout. Treating Hybrid as a "dialect whose rules are composition rules" keeps the template uniform.
+
+**Relationship to the six runtime-specific dialect docs.** This doc is light on content compared to the others because it delegates almost everything to them. Its job is to specify the composition procedure. A reader working on a specific Hybrid (say, OpenClaw + Claude Code) uses *this* doc for the merge rules, the OpenClaw doc for OpenClaw-specific details, and the Claude Code doc for Claude Code-specific details. Hybrid is the glue, not the substance.
+
+Open questions:
+
+- **§1a's "common pairings" table** is based on plausible scenarios, not measured data. Worth corpus-testing to see which hybrids actually appear in practice — some of the listed pairings may never occur, and unlisted ones may be more common than expected.
+- **§4b's "primary wins" default** is opinionated. An alternative ("merge always, flag conflicts as critical") is defensible but more disruptive. The conservative default keeps generation moving; a v2 could offer `--hybrid-resolution=primary|merge|halt`.
+- **§6a's Agent Skills std + Claude Code promotion** is a special case. There might be other "superset/subset" pairings we should handle similarly — e.g., if AutoGen 0.2 and 0.4 signals tie (same runtime, different versions), should we promote to the newer? Not addressed in v1; flagged for when more runtimes are added.
+- **§4d merged metadata** assumes metadata from different runtimes is compatible to combine. If runtimes encode conflicting metadata (e.g., one runtime's `reasoning_mode: "plan"` and another's `reasoning_mode: "exec"` for the same element), merge is unsafe. Worth adding a metadata-conflict-detection rule.
+- **§6b cross-framework Python imports** flags bridge files but doesn't suggest how to handle them. A file importing both `langgraph` and `autogen_agentchat` is either a Hybrid artifact or a genuine bridge module; the distinction matters for generation but isn't automated.
+- **No detection signals for Hybrid-specific intent.** Some specs are authored with hybrid intent from the start (e.g., a project that deliberately uses Claude Code for dev ergonomics and OpenClaw for deployment). Others are hybrid by accident (artifact directories from a migration). Step 0 cannot distinguish these; Rule 6d's `--source-runtime` override is the only user-side recourse. Worth considering a `--hybrid-intent=authored|accidental` flag for richer treatment.
+- **Three-way Hybrid workflow** (§6c) works in principle but elicitation UX grows linearly. A real user facing 15 conflicts across three runtimes may abandon elicitation. v2 could add conflict-grouping or batch resolution.
+- **Schema-level formalisation** — `hybrid_primary` and `hybrid_contributors` fields are specified here but need to be added to the formal `classification.json` JSON Schema (deferred task per `spec.md`). Same for the `conflict` field in `element_mapping.json`.

--- a/docs/dialects/langgraph.md
+++ b/docs/dialects/langgraph.md
@@ -1,0 +1,493 @@
+# LangGraph Dialect
+
+**Version**: 1.0.0
+**Status**: Fourth dialect doc. First code-first dialect; stress-tests the template against a runtime whose spec is primarily Python code rather than structured text.
+
+**Prerequisite reading**: `spec.md` R1 (detection), R22 (dialect mapping contract), R21 (modality); `plans/dialects/openclaw.md` (reference template); `plans/dialects/letta.md` (single-file-JSON adaptation); `plans/dialects/claude-code.md` (feature-rich Markdown workspace); `plans/generated-package-shape.md` (output shape); `plans/steps/step-1a-inventory.md`, `plans/steps/step-1b-tagging.md`.
+
+---
+
+## What this document does
+
+Describes the concrete rules melleafy applies when processing a **LangGraph** source spec. LangGraph differs fundamentally from the Markdown/JSON dialects: **graph structure, state, nodes, and tools are all Python code**. There is exactly one declarative file in the LangGraph ecosystem — `langgraph.json` — and it exists only for LangGraph Platform deploys; many OSS LangGraph projects have no `langgraph.json` at all.
+
+This dialect doc is the first to confront code-as-spec. The template's Section 2 (File inventory) therefore names **inventory surfaces within Python code** — AST-discoverable patterns — rather than files.
+
+Key LangGraph concepts readers should have in mind:
+
+- **StateGraph**: the graph builder. Accepts a state schema (`TypedDict` or Pydantic model), accumulates nodes and edges, compiles to a runnable graph.
+- **State schema**: typically a `TypedDict` with `Annotated[list, add_messages]` fields or similar reducers.
+- **Nodes**: Python functions `(state: State) -> State` or `(state: State) -> Command(...)`.
+- **Edges**: `add_edge(src, dst)`, or conditional `add_conditional_edges(src, router_fn, {"label": "dst"})`.
+- **Compile-time configuration**: `interrupt_before=[...]`, `interrupt_after=[...]`, `checkpointer=...`, `store=...`.
+- **Runtime invocation**: `graph.invoke(state, config)`, `graph.stream(...)`, `graph.astream_events("v2", ...)`.
+- **`langgraph.json`**: optional declarative manifest for LangGraph Platform deploys — names the graph entry points, dependencies, env, checkpointer, store config.
+
+---
+
+## 1. Detection signals
+
+| Signal | Strength | Notes |
+|---|---|---|
+| `langgraph.json` present in workspace | strong | The only declarative LangGraph file; presence is unambiguous |
+| Python file containing `from langgraph.graph import StateGraph` | strong | The canonical import; defining signal |
+| Python file containing `Annotated[..., add_messages]` | strong | LangGraph-specific state-reducer idiom |
+| Python file containing `StateGraph(<X>)` constructor call | strong | Graph-definition pattern |
+| Python file referencing `checkpointer`, `Checkpointer`, or `MemorySaver` | medium | Characteristic of LangGraph persistence |
+| Python file referencing `interrupt_before=[...]` or `interrupt(...)` | medium | Human-in-the-loop pattern |
+| Python file referencing `Command(goto=...)` | medium | LangGraph-specific control flow |
+| Python file referencing `Send(...)` API | medium | Dynamic branching |
+| Python file referencing `BaseStore`, `InMemoryStore`, or `PostgresStore` | medium | LangGraph Store (long-term memory) |
+| Import of `langgraph.prebuilt` | weak | Prebuilt agents; not definitive but suggestive |
+
+**Disambiguating from other code-first runtimes.** Other v1-supported code-first runtimes (AutoGen, OpenAI Agents SDK, smolagents) have distinct imports:
+- `from autogen_agentchat import ...` → AutoGen
+- `from agents import ...` (with Agent SDK conventions) → OpenAI Agents SDK
+- `from smolagents import CodeAgent, ToolCallingAgent` → smolagents
+
+A spec containing both LangGraph and one of these other runtimes' imports is Hybrid.
+
+**Precedence note.** R1 tiebreak order puts LangGraph after CrewAI but before AutoGen and others. In practice, LangGraph's signals (`StateGraph`, `add_messages`) are highly distinctive — `StateGraph` appears in no other runtime. Signal-count ties are rare.
+
+**Hybrid threshold.** A project that uses LangGraph for orchestration and CrewAI for crew definitions is a plausible Hybrid. A project that imports both `langgraph` and `autogen_agentchat` is either Hybrid or one is a peripheral test file — melleafy's default is Hybrid; user can override.
+
+**Handling the "no langgraph.json" case.** When `langgraph.json` is absent, detection relies entirely on Python-file imports. Step 1a's workspace traversal reads all `.py` files (subject to the 50 MB cap) and Step 0 scans their imports. The primary spec is the file the user passed to melleafy on the command line — it must contain at least one strong LangGraph signal.
+
+---
+
+## 2. Inventory surfaces (Step 1a, Step 1b)
+
+The template's Section 2 normally describes "files to read." For LangGraph, it describes **inventory surfaces** — AST patterns melleafy discovers inside Python files. Step 1a reads all Python files; Step 1b's section-discovery pass walks the AST to locate surfaces.
+
+### 2a. The declarative surface: `langgraph.json` (if present)
+
+When `langgraph.json` exists, it's parsed fully per its documented fields. This is the only non-code surface for LangGraph specs.
+
+| JSON path | Role in spec | Inventory action |
+|---|---|---|
+| `graphs.<n>` | Names the graph entry point as `./path:var_name` | Drives which Python file is primary; becomes C8 metadata |
+| `dependencies[]` | Python package requirements | Each becomes C8 element |
+| `python_version` | Target Python version | C8 element |
+| `env` | Either dict, `.env` path, or list of var names | C7 elements |
+| `dockerfile_lines[]` | Dockerfile addenda | C8 elements |
+| `pip_config_file` | pip config override | C8 element |
+| `docker_compose_file` | External docker-compose reference | C8 element |
+| `api_version` | Platform API version pin | C8 element |
+| `checkpointer` | Checkpointer config (TTL, serde) | C4 element; `delegate_to_runtime` |
+| `store` | Store config (index/embeddings) | C5 element; `delegate_to_runtime` |
+| `auth` | Auth handler as `"pkg:obj"` reference | C2 element |
+| `http` | HTTP-server config | C8 element |
+| `webhooks` | Webhook definitions — LangGraph Platform feature | C9 element (event_triggered); `delegate_to_runtime` |
+| `encryption` | Encryption config for stored state | C7-adjacent; C8 element |
+
+**Rule 2a-1**: `langgraph.json` may be absent. When absent, every entry above that would have a value is *inferred from code signals* where possible — e.g., `checkpointer` inference from `.compile(checkpointer=...)` calls, `store` from `BaseStore` references. Inferred entries are marked with `source_of_decision: "inferred"` in `inventory.json`.
+
+### 2b. The code surfaces
+
+These are the AST patterns Step 1b's section-discovery pass identifies in each Python file. Each pattern produces one or more elements; exactly what category and tag depends on the pattern.
+
+| Pattern | Role | Category | Typical tag |
+|---|---|---|---|
+| `StateGraph(<T>)` constructor call | Entry point for graph structure | — | `ORCHESTRATE` |
+| TypedDict/Pydantic class used as graph state `<T>` | State schema | — | `SCHEMA` |
+| `Annotated[<type>, <reducer>]` field in state schema | Field with reducer (e.g., `add_messages`) | — | `SCHEMA` (with metadata about the reducer) |
+| Named function `def <n>(state: State) -> State` added to graph via `add_node` | A graph node | C1/C2/C6 depending on purpose | `EXTRACT`, `CLASSIFY`, `TRANSFORM`, etc. |
+| Function returning `Command(goto=..., update=...)` | Node with dynamic control flow | — | `ORCHESTRATE` |
+| `add_edge(src, dst)` call | Static edge | — | `ORCHESTRATE` |
+| `add_conditional_edges(src, router, {...})` call | Conditional edge + router function | — | `ORCHESTRATE` + `DECIDE` for the router |
+| `.compile(interrupt_before=[...])` | Compile-time review-gated points | — | Modality signal (see §5) |
+| `.compile(interrupt_after=[...])` | Same | — | Same |
+| `.compile(checkpointer=...)` | Checkpointer binding | C4 | `ORCHESTRATE` |
+| `.compile(store=...)` | Store binding | C5 | `ORCHESTRATE` |
+| `interrupt(<payload>)` call inside a node body | Dynamic review-gated pause | — | Modality signal |
+| `@tool` decorator on a function | Tool declaration | C6 | `TOOL_TEMPLATE` |
+| `BaseTool` subclass | Tool declaration | C6 | `TOOL_TEMPLATE` |
+| `Send(node, state_fragment)` in a router | Dynamic branching | — | `ORCHESTRATE` |
+| Prompt template strings (in node bodies) | Prompt content | C1/C2 depending on content | `CONFIG` or inline inside node |
+| `from X import tool_name` where `X` is an MCP/adapter package | External tool import | C6 | `TOOL_TEMPLATE` (delegate) |
+
+### 2c. Section discovery for Python code
+
+Step 1b's section-discovery pass (plans/steps/step-1b-tagging.md §3a) walks the AST to identify candidate element boundaries. For LangGraph, the pass runs these discovery queries on each Python file:
+
+1. All `ast.Call` nodes where the callable is `StateGraph`.
+2. All `ast.ClassDef` referenced as the State type of a StateGraph.
+3. All `ast.FunctionDef` referenced in `add_node` calls.
+4. All `ast.Call` nodes with `.add_edge`, `.add_conditional_edges`, `.compile` method names.
+5. All `ast.Call` nodes whose callable resolves to `@tool` decoration or `BaseTool` subclass instantiation.
+
+Each discovered pattern becomes a candidate boundary with `rough_kind` set appropriately (`schema`, `node`, `edge`, `tool`, `compile_config`). Step 1b's element-refinement pass then processes each candidate individually — exactly the same flow as for Markdown, just with Python-derived boundaries.
+
+**Rule 2c-1**: AST walking is the *only* source of boundaries for LangGraph. Step 1b does not attempt to split Python source files at arbitrary line boundaries — that would produce half-expressions and fragment nodes. AST-derived boundaries respect the syntax tree.
+
+### 2d. Source lines convention for code
+
+LangGraph elements use a Python-aware `source_lines` format:
+
+- `"py:<line_start>-<line_end>"` — a contiguous range of source lines corresponding to an AST node
+- `"py:<file>:<line_start>-<line_end>"` — when multiple Python files are inventoried (most LangGraph projects have ≥2 files: graph + state)
+- `"py:<file>:<func_name>"` — shorthand for "the full body of the named function/class"
+
+This is a third `source_lines` convention, joining Letta's `json:<path>` and Claude Code's `frontmatter.<field>`. Step 1b is aware of all three. See the ratification notes for the formalisation task.
+
+### 2e. Multi-file LangGraph projects
+
+A real LangGraph project typically has:
+
+- `graph.py` — defines the StateGraph, nodes, compile call
+- `state.py` — defines the TypedDict
+- `tools.py` — defines tools
+- `prompts.py` — prompt templates as string constants
+- `langgraph.json` — if deployed to LangGraph Platform
+
+Melleafy's Step 1a reads all Python files in the workspace; each is inventoried per the surfaces above. Cross-file references (e.g., `graph.py` imports `State` from `state.py`) are resolved by the AST walker using standard Python import semantics — the inventory records the originating file for each element regardless of where the graph is assembled.
+
+**Rule 2e-1**: the *primary spec file* passed on the command line becomes the "entry-point file" — the one that builds the StateGraph. Other Python files in the workspace are "supporting files." Step 1b inventories all of them, but the mapping report in Step 5 distinguishes entry-point from supporting contributions.
+
+**Rule 2e-2**: files not reachable from the primary spec's import graph are **still inventoried** (melleafy is conservative about file scope). They appear in the report with a note that they're unreachable. This protects against accidentally omitting relevant files due to lazy imports or dynamic imports.
+
+### 2f. Python file discovery and limits
+
+- Step 1a's 50 MB workspace cap applies.
+- Python files over 10 MB are rejected (unlikely for a LangGraph spec, but the limit exists).
+- `__pycache__`, `.venv`, `venv`, `env`, `.pytest_cache`, `node_modules` are skipped per Step 1a §1a.4.
+- Test files matching `test_*.py` or `*_test.py` are inventoried but marked with `role: "test"` — they're typically not part of the spec, though they may contain fixtures melleafy can learn from.
+
+### 2g. Supporting files (non-Python)
+
+| File | Role | Inventory action |
+|---|---|---|
+| `pyproject.toml` / `requirements.txt` / `setup.py` | C8 dependencies | Parse; elements per package |
+| `.env` / `.env.example` | C7 credentials | Parse; one element per var |
+| `README.md` (if present) | Free-form notes | NO_DECOMPOSE unless spec references it |
+| `.mcp.json` (rare but possible) | C6 MCP tools | Inventoried if present — LangGraph can consume MCP via adapter libraries |
+
+---
+
+## 3. Structured-content rules
+
+LangGraph has two kinds of structured content: JSON (`langgraph.json`) and Python source.
+
+### 3a. `langgraph.json` parsing
+
+Parsed with `json.loads`. Schema validation is permissive: only `graphs` is strictly required (and even that's only required when deploying). Unknown fields are preserved and surfaced in the mapping report's "Detected but not handled" section.
+
+**Rule 3a-1**: the `env` field accepts three shapes (dict, `.env` path string, list of var names). Each shape is handled:
+
+- dict → each key-value becomes a C7 element with literal default
+- `.env` path → read the referenced file, parse for var names
+- list of strings → each string is a var name with no default
+
+Melleafy normalises all three into the same C7 element shape in `inventory.json`.
+
+### 3b. Python AST parsing
+
+Melleafy uses Python's `ast` module to parse `.py` files. Syntax errors are recoverable at the file level — if `graph.py` fails to parse, other Python files still inventory. The failed file is recorded in the inventory report with `status: "syntax_error"` and the error position. The mapping report names which file failed.
+
+**Rule 3b-1**: melleafy does not attempt to repair broken Python source. If the primary spec has a syntax error, Step 0's detection may succeed (based on other Python files) but Step 1b will fail to produce a complete inventory. This manifests as a coverage-threshold halt in Step 1b's cross-checks.
+
+### 3c. Docstring and comment handling
+
+Python function and class docstrings *are* inventoried content. Module-level docstrings describe the spec's overall intent; function docstrings describe node purposes. Both become part of the `content_full` for the element containing them.
+
+Comments (`# ...`) are *not* inventoried. They're developer-targeted explanation, not spec content. A comment like `# TODO: refactor this` is not meaningful to melleafy's downstream tagging.
+
+### 3d. Type annotations
+
+Type annotations on function parameters and return types *are* inventoried. A node with signature `def extract(state: ExtractState) -> ExtractState` tells Step 1b the state types involved, which informs schema mapping decisions. Type hints are read from `typing` and `Annotated` forms specifically.
+
+---
+
+## 4. Dialect mapping table
+
+| Source signal | Category | Default disposition | Generation target |
+|---|---|---|---|
+| `StateGraph(<T>)` construction | — | `bundle` | Skipped — state-graph assembly is conceptually replaced by Mellea pipeline, not reproduced |
+| State TypedDict / Pydantic class (`<T>`) | — | `bundle` | `schemas.py:<ClassName>` — the state schema becomes a Mellea Pydantic model |
+| State field with `Annotated[list, add_messages]` | — | `bundle` | `schemas.py` field with a standard `list[Message]` type; the reducer is not reproduced |
+| State field with other reducer (`operator.add`, custom) | — | `bundle` with warning | Same; reducer behavior not reproduced — listed in "Runtime-specific constructs not reproduced" |
+| Node function body referencing prompt strings | C1 / C2 | `bundle` | `config.<NODE>_PROMPT` constant + `m.instruct()` call in `pipeline.py` |
+| Node function body with typed structured output | — | `bundle` | `@generative` slot or `m.instruct(format=Schema)` in pipeline |
+| Node function body returning `Command(goto=X, update=Y)` | — | `bundle` | Plain Python control flow in `pipeline.py` — `goto` translates to explicit sequencing |
+| Router function used in `add_conditional_edges` | — | `bundle` | `pipeline.py` function with `DECIDE`-tagged semantics |
+| `add_edge(src, dst)` call | — | *(not reproduced)* | Implicit in pipeline sequencing |
+| `add_conditional_edges(src, router, {label: dst, ...})` | — | `bundle` | `pipeline.py:if/elif/else` chain based on router output |
+| `.compile(interrupt_before=[...])` | C2 + modality | `delegate_to_runtime` | Modality classification (see §5); SETUP.md §7 documents checkpointer requirement |
+| `.compile(interrupt_after=[...])` | Same | Same | Same |
+| `interrupt(<payload>)` dynamic call | Same | Same | `constrained_slots.py:resume_point` stub; SETUP.md §7 |
+| `.compile(checkpointer=...)` | C4 | `delegate_to_runtime` | `constrained_slots.py:load_checkpoint, save_checkpoint`; SETUP.md §4 |
+| `.compile(store=BaseStore(...))` | C5 | `delegate_to_runtime` | `constrained_slots.py:store_get, store_put`; SETUP.md §5 |
+| `@tool`-decorated function body | C6 | `real_impl` (if Python concrete) | `tools.py:<tool_name>` |
+| `BaseTool` subclass with `_run` method | C6 | `real_impl` | `tools.py:<tool_name>` |
+| Tool imported from `langchain_community.tools` | C6 | `stub` (v1 doesn't bundle langchain_community) | `constrained_slots.py:<tool_name>`; SETUP.md §8 |
+| `Send(<node>, <state>)` in a router | — | `bundle` | `pipeline.py` parallel execution via `asyncio.gather` or ordered for-loop (semantics preserved) |
+| `langgraph.json:dependencies[]` | C8 | `bundle` | Appended to `pyproject.toml:dependencies` |
+| `langgraph.json:env.<VAR>` (dict form) | C7 | `external_input` | `.env.example` with the declared default |
+| `langgraph.json:env` as `.env` path | C7 | `external_input` | `.env.example` generated from the referenced `.env` |
+| `langgraph.json:env[]` (list form) | C7 | `external_input` | `.env.example` with empty defaults |
+| `langgraph.json:auth.path` | C2 | `delegate_to_runtime` | `constrained_slots.py:auth_handler`; SETUP.md documents the auth object shape |
+| `langgraph.json:http.*` config | C8 | `bundle` | `config.HTTP_CONFIG` dict |
+| `langgraph.json:webhooks[]` | C9 (event_triggered) | `delegate_to_runtime` | `handlers/` directory with per-webhook stubs; SETUP.md §7 |
+| `langgraph.json:checkpointer` config | C4 | `delegate_to_runtime` | Same as compile-time checkpointer |
+| `langgraph.json:store` config | C5 | `delegate_to_runtime` | Same as compile-time store |
+| `langgraph.json:encryption` | C7 | *(not reproduced)* | v1 doesn't reproduce checkpointer encryption; listed in not-reproduced |
+| `langgraph.json:dockerfile_lines[]` | C8 | *(not reproduced)* | Listed in "Detected but not handled" — v1 produces pure-Python packages |
+| LangGraph Platform cron reference (POST /runs/crons) | C9 (scheduled) | `delegate_to_runtime` | Noted in SETUP.md §6; v1 generates the pipeline, not the cron registration |
+| Module-level docstring | C1 | `bundle` (if describes agent intent) | `config.AGENT_DESCRIPTION` |
+| Node function docstring | C1 per node | `bundle` | Docstring preserved on generated `@generative` slot or pipeline helper |
+
+**Override semantics.** Default dispositions can be overridden via `--dependencies=ask` or `config:<path>` per the standard R22 contract.
+
+**Rule 4-1**: the "state graph" concept itself is not reproduced. Melleafy's generated pipeline is a sequential/branching Python function, not a `StateGraph`-equivalent. The mapping semantically translates `add_node(X, fn)` + `add_edge(X, Y)` into "call `fn` then call `fn_Y` in `run_pipeline`." This is a **semantic translation**, not a structural mirror — and the mapping report's Provenance appendix documents the translation for each node.
+
+---
+
+## 5. Modality signals (Step 0 Axis 5, R21)
+
+LangGraph's modality signals are largely at the `.compile(...)` call site and the invocation site.
+
+| Signal | Modality classification |
+|---|---|
+| `graph.invoke(state, config)` in spec body or docstrings | **`synchronous_oneshot`** |
+| `graph.stream(...)` or `graph.astream_events("v2", ...)` | **`streaming`** |
+| `graph.invoke(..., config={"configurable": {"thread_id": ...}})` + checkpointer | **`conversational_session`** — thread_id + checkpointer is the LangGraph conversational idiom |
+| `.compile(interrupt_before=[...])` or `.compile(interrupt_after=[...])` | **`review_gated`** (primary if no other invocation pattern present; secondary if composed with invoke/stream) |
+| `interrupt(<payload>)` in node bodies | **`review_gated`** (dynamic form) |
+| `langgraph.json:webhooks[]` | **`event_triggered`** (LangGraph Platform only) |
+| LangGraph Platform cron (`POST /runs/crons`) | **`scheduled`** (LangGraph Platform only) |
+| None of the above | **`synchronous_oneshot`** — the default assumption |
+
+**Composition.** LangGraph is known for the `conversational + review_gated` HITL tutorial pattern — thread_id + checkpointer + `interrupt()`. This is the canonical composition. Melleafy emits it as:
+- Primary: `conversational_session`
+- Secondary: `review_gated`
+- Generated shape: conversational (§5c/§5d of shape doc) with explicit "resume_point" stubs at the interrupt locations
+
+Other compositions:
+- **`streaming + review_gated`** — possible but unusual; flag for manual review
+- **`scheduled + review_gated`** — Platform-only; awkward (who resumes a cron-fired interrupt?); flag for manual review
+
+**Generated shape per R21.** The four composable primaries that emit to pure Mellea Python are: `synchronous_oneshot`, `streaming`, `conversational_session`, `conversational + memory`. LangGraph's `review_gated` and Platform-only `scheduled`/`event_triggered` are host-needing — they fall back to `synchronous_oneshot` shape with SETUP.md §5/§6/§7 guidance.
+
+### 5a. Checkpointer detection is load-bearing for modality
+
+A LangGraph spec using `thread_id` in invocation configs without a `.compile(checkpointer=...)` call is **non-functional** (threads require a checkpointer to persist). Step 0's modality classifier flags this:
+
+- If `thread_id` is referenced but no checkpointer is declared, classify as `conversational_session` but add a warning: "Spec uses thread_id without a checkpointer declaration. SETUP.md §4 will require configuring one."
+
+### 5b. LangGraph OSS vs LangGraph Platform
+
+Several LangGraph modalities are **Platform-only** (closed-source, license-gated):
+
+- `scheduled` (cron via `POST /runs/crons`)
+- `event_triggered` (webhooks via `langgraph.json:webhooks`)
+
+Melleafy records these as detected but classifies them as `delegate_to_runtime`. The generated package doesn't reproduce Platform behavior — the user must host the pipeline on LangGraph Platform to use these modalities, or adapt with an external scheduler/webhook server. SETUP.md §6/§7 names the options.
+
+---
+
+## 6. Quirks and workarounds
+
+### 6a. Graph structure is not reproduced — semantics are
+
+The biggest conceptual gap between LangGraph and Mellea: Mellea has no `StateGraph` equivalent. A LangGraph spec's graph is the structural skeleton — nodes, edges, state — but melleafy generates **sequential Python code with branches** that executes the same semantics.
+
+Example translation:
+
+LangGraph source:
+```python
+builder = StateGraph(State)
+builder.add_node("extract", extract_fn)
+builder.add_node("summarize", summarize_fn)
+builder.add_edge(START, "extract")
+builder.add_edge("extract", "summarize")
+builder.add_edge("summarize", END)
+graph = builder.compile()
+```
+
+Melleafy generated:
+```python
+def run_pipeline(input: Input) -> Output:
+    with start_session() as m:
+        state = State(input=input)
+        state = _extract(state, m)    # was the "extract" node
+        state = _summarize(state, m)  # was the "summarize" node
+        return state.output
+```
+
+This works for simple linear flows. For branches (via `add_conditional_edges` or `Command(goto=X)`), the translation becomes explicit `if/elif/else` in `pipeline.py`. For `Send(...)` (dynamic parallel), the translation uses `asyncio.gather` or a for-loop.
+
+**Rule 6a-1**: the mapping report's Provenance appendix documents this translation per-graph. A reviewer comparing the source graph to the generated pipeline sees:
+- Which node became which Python helper
+- Which edge became which sequential/conditional/parallel construct
+- Which compile-time options became SETUP.md sections
+
+### 6b. State reducers are behavior, not structure
+
+LangGraph state fields can carry reducers — `Annotated[list, add_messages]` means "when a node returns messages, append them to the list." The most common reducer is `add_messages`; others include `operator.add` for concatenating lists.
+
+**Rule 6b-1**: v1 melleafy does not reproduce reducers. The generated `schemas.py` has a plain `list[Message]` field. Nodes that produced partial state updates (returning `{"messages": [new_msg]}` to be merged) are translated to explicit mutation (`state.messages.append(new_msg)`). This matches semantics for `add_messages` and `operator.add` but not for custom reducers.
+
+**Rule 6b-2**: custom reducers (functions other than `add_messages` and standard operators) are flagged in the mapping report's "Runtime-specific constructs not reproduced" section with their specific reducer name and function signature, so users reviewing can decide whether the explicit-mutation translation is semantically equivalent.
+
+### 6c. No native scheduling or webhooks in OSS
+
+LangGraph's OSS distribution has no scheduling module or webhook handler. These features exist only in LangGraph Platform. A spec that declares `langgraph.json:webhooks` or references Platform cron:
+
+- Is still inventoried (the declarations are spec content)
+- Categorised as C9 event_triggered / scheduled
+- Default disposition is `delegate_to_runtime`
+- SETUP.md §6 / §7 explicitly notes "LangGraph OSS has no scheduler; use external cron or deploy to LangGraph Platform"
+
+### 6d. `thread_id` flows via config, not function argument
+
+LangGraph's conversational pattern uses `config={"configurable": {"thread_id": "..."}}` passed to `invoke`. This is a runtime configuration channel, not a function parameter.
+
+**Rule 6d-1**: melleafy's generated `run_pipeline(session, message)` signature for conversational mode uses a MelleaSession parameter — the analog to LangGraph's thread_id + checkpointer is the session object. The mapping is:
+
+- LangGraph `thread_id` → Mellea `session.id`
+- LangGraph checkpointer → Mellea session's chat context storage
+- LangGraph `invoke(None, config)` (resume) → not directly expressible; handled via SETUP.md §7 for review-gated specs
+
+### 6e. Subgraphs are Python objects
+
+LangGraph supports subgraphs — one StateGraph used as a node in another. v1 melleafy:
+
+- Inventories each StateGraph definition as its own unit
+- For subgraphs used as nodes: the subgraph's nodes are *inlined* into the parent pipeline's node list, prefixed with the subgraph name (e.g., `subgraph_foo.extract`, `subgraph_foo.summarize`)
+- Alternatively, if inline-expansion is inappropriate (e.g., subgraph is itself complex), treat as a Deferred Item
+
+**Rule 6e-1**: the decision between inlining and deferring is a Step 2 judgement call (subgraph with fewer than 5 nodes inlines; larger subgraphs defer with a warning). This is a specifically LangGraph-driven Step 2 decision that generalises from the standard Step 2 mapping.
+
+### 6f. `Send` API for dynamic parallelism
+
+The `Send(node, state_fragment)` API lets a router dynamically dispatch parallel branches. Translating to Mellea:
+
+- Static parallelism (known branch count) → `asyncio.gather(...)` in `pipeline.py`
+- Dynamic parallelism (branch count derived at runtime) → `asyncio.gather(*[node_fn(s) for s in state_fragments])` with explicit collection
+
+Both translations preserve semantics; the choice is a Step 2 decision based on whether the router is static or dynamic.
+
+### 6g. Checkpointer tables are implementation detail
+
+LangGraph's SQLite checkpointer writes tables `checkpoints` + `writes`; Postgres uses `checkpoints` + `checkpoint_blobs` + `checkpoint_writes`. These are internal schemas melleafy does not need to reproduce. SETUP.md §4 names Mellea-compatible alternatives (in-memory session state for ephemeral use; SQLite or Redis for persistence via user-supplied adapter).
+
+**Rule 6g-1**: if a spec explicitly references the LangGraph checkpointer SQL schema (very rare — typically only in migration scripts), the schema is inventoried but not reproduced. It's listed in "Runtime-specific constructs not reproduced."
+
+### 6h. LangGraph Platform Store namespace semantics
+
+LangGraph Store uses `(namespace_tuple, key) → value` with optional vector indexing. This is a structured store model — richer than a flat key-value. The `namespace_tuple` is typically `(user_id, resource_type)`.
+
+**Rule 6h-1**: v1 melleafy stubs store access in `constrained_slots.py:store_get(namespace_tuple, key)` and `store_put(...)`. The user's adapter implementation can use any backend (Redis, Postgres, or a LangGraph Store if they want). The namespace structure is preserved in the stub signature.
+
+### 6i. Auth object shape
+
+`langgraph.json:auth` references a Python object via `"pkg:obj"` string. The referenced object is typically a callable or class. v1 doesn't execute or introspect the referenced object — melleafy records the reference in `constrained_slots.py:auth_handler` with a SETUP.md §2 note explaining the shape the user must provide.
+
+### 6j. `langchain_community` tool imports
+
+Many real LangGraph projects import tools from `langchain_community.tools` (e.g., `DuckDuckGoSearchRun`). v1 melleafy does not bundle `langchain_community`:
+
+- Tool is inventoried with its class name
+- Disposition defaults to `stub`
+- `constrained_slots.py` stub includes a SETUP.md §8 note naming the langchain_community class and how the user can wire it
+
+This is intentional — `langchain_community` has many dependencies, some of which are unfree or problematic. v2 may add opt-in bundling.
+
+---
+
+## 7. Reference inventory output (illustrative)
+
+For a minimal LangGraph spec — `graph.py`, `state.py`, and a `langgraph.json`:
+
+### Inventory (abridged)
+
+```json
+{
+  "elements": [
+    {"element_id": "elem_001", "source_file": "state.py", "source_lines": "py:state.py:1-15", "tag": "SCHEMA", "category": "—", "content_summary": "State TypedDict with messages + extracted claims"},
+    {"element_id": "elem_002", "source_file": "graph.py", "source_lines": "py:graph.py:10-25", "tag": "EXTRACT", "category": "C1", "content_summary": "extract_claims node: pulls structured claims from input text"},
+    {"element_id": "elem_003", "source_file": "graph.py", "source_lines": "py:graph.py:28-42", "tag": "DECIDE", "category": "C2", "content_summary": "route_verified: decides whether claims need additional verification"},
+    {"element_id": "elem_004", "source_file": "graph.py", "source_lines": "py:graph.py:60-65", "tag": "ORCHESTRATE", "category": "—", "content_summary": "compile() with MemorySaver checkpointer; interrupt_before=['verify']"},
+    {"element_id": "elem_050", "source_file": "langgraph.json", "source_lines": "json:graphs.main", "tag": "CONFIG", "category": "C8", "content_summary": "Primary graph entry: ./graph.py:graph"},
+    {"element_id": "elem_051", "source_file": "langgraph.json", "source_lines": "json:env.OPENAI_API_KEY", "tag": "CONFIG", "category": "C7", "content_summary": "Required env var: OPENAI_API_KEY"}
+  ]
+}
+```
+
+### Element mapping (abridged)
+
+```json
+{
+  "mappings": [
+    {"element_id": "elem_001", "target_file": "schemas.py", "target_symbol": "State", "primitive": "bundle"},
+    {"element_id": "elem_002", "target_file": "slots.py", "target_symbol": "extract_claims", "primitive": "@generative"},
+    {"element_id": "elem_003", "target_file": "pipeline.py", "target_symbol": "_route_verified", "primitive": "decide"},
+    {"element_id": "elem_004", "target_file": "constrained_slots.py", "target_symbol": "checkpoint_and_interrupt", "primitive": "stub"},
+    {"element_id": "elem_050", "target_file": "config.py", "target_symbol": "GRAPH_NAME", "primitive": "bundle"},
+    {"element_id": "elem_051", "target_file": ".env.example", "target_symbol": "OPENAI_API_KEY", "primitive": "external_input"}
+  ]
+}
+```
+
+### Dialect-specific notes in the mapping report
+
+- A "Graph-to-pipeline translation" section showing how each LangGraph node became a Python helper in `pipeline.py`, and which edges became sequential vs conditional vs parallel constructs.
+- A "Runtime-specific constructs not reproduced" section listing `operator.add` / custom reducers, `Command(goto=...)` dynamic routing that couldn't be statically traced, `Send` API where parallelism was dynamic, checkpointer SQL schema references.
+- A "LangGraph OSS limitations" callout when the spec referenced Platform-only features (scheduling, webhooks).
+
+---
+
+## 8. Deferred LangGraph features (not handled in v1)
+
+- **Subgraph inline-expansion heuristic** (§6e) is a provisional 5-node threshold. Real corpus data may suggest a different rule.
+- **Custom state reducers** beyond `add_messages` / `operator.add` — listed in not-reproduced; v2 could emit helper functions that apply the reducer explicitly.
+- **`Send` API with fully-dynamic branch counts** — v1 handles static and list-comprehension-driven dynamic cases; truly runtime-determined parallelism (e.g., branch count from an LLM response) is deferred.
+- **LangGraph Platform features** — scheduling, webhooks, encryption, auth resolution. These require Platform hosting, outside v1's scope.
+- **`langchain_community` tools** — not bundled. User wires via stub.
+- **Durable workflows via Temporal** (occasionally used with LangGraph for long-running state) — entirely separate runtime model; not in scope.
+- **Streaming events decomposition** — LangGraph's `astream_events("v2")` produces structured events (`on_chain_start`, `on_tool_end`, etc.). V1 emits a simple streaming generator; users who need structured events wire them themselves.
+- **Auth callbacks** with complex state — `langgraph.json:auth` is stubbed with a simple signature; richer auth patterns (per-user token refresh, session-bound scopes) are deferred.
+- **Dynamic graph construction** — if a spec builds StateGraphs conditionally at runtime (e.g., different graphs for different user tiers), v1 can't statically inventory them all. Listed as Deferred.
+
+---
+
+## 9. Cross-references
+
+- `spec.md` R1, R21, R22 — the contracts this dialect implements
+- `plans/dialects/openclaw.md` — template this dialect adapts
+- `plans/dialects/letta.md` — JSON-file-source comparison
+- `plans/dialects/claude-code.md` — Markdown-workspace comparison
+- `plans/steps/step-1a-inventory.md` — file reading; Python files handled per §2f
+- `plans/steps/step-1b-tagging.md` — section-discovery pass; AST walking covered in §3a
+- `plans/generated-package-shape.md` — shape of the generated output
+- `glossary.md` — `dialect`, `disposition`, `interaction modality`
+- `melleafy.json` schema — the manifest fields this dialect populates
+
+---
+
+## 10. Ratification notes
+
+This dialect doc v1.0.0 was the fourth drafted. Selection was deliberate: LangGraph is the first code-first dialect, and its template-fit validates (or challenges) the 10-section shape against a fundamentally different source-spec model.
+
+**What the template survived unchanged:**
+- Section 1 (Detection signals) — worked identically. Signal counting doesn't care whether signals are frontmatter fields or Python imports.
+- Section 4 (Dialect mapping table) — the four-column shape accommodated AST patterns as "source signals" without restructure. The mapping table is shorter than Claude Code's but conceptually more dense per row.
+- Section 5 (Modality signals) — code patterns fit the signal table format. Runtime invocation idioms (`graph.invoke`, `graph.stream`) are just another kind of signal.
+- Sections 6–10 — translated directly.
+
+**What the template needed to adapt:**
+- **Section 2 (Inventory surfaces)** — became "AST patterns inside Python code" instead of "files in a workspace." The underlying intent (enumerate the source surfaces inventory reads from) is preserved; the surfaces are different. Subsections 2b (code surfaces table) and 2c (section discovery for Python code) are new shape Section 2 needed.
+- **Section 3 (Structured-content rules)** — became about JSON parsing + Python AST parsing instead of YAML frontmatter. The intent (specify how structured content is read and validated) is preserved.
+- **Source lines convention (§2d)** — introduced `py:<file>:<range>` as a third format alongside Letta's `json:<path>` and Claude Code's `frontmatter.<field>`. Three data points now; worth formalising.
+
+**What this tells us about template generality.** The template fits code-first runtimes as well as text-first ones, provided Section 2 is understood as "enumerate the inventory surfaces" rather than "list the files to read." The source-surface abstraction is the template's actual contract. This is a useful reframing for the remaining code-first dialects (AutoGen, OpenAI Agents SDK, smolagents).
+
+Open questions:
+
+- **§2c AST section discovery** specifies a fixed list of discovery queries. Real LangGraph specs may use patterns the list doesn't cover (e.g., a metaprogramming trick that generates nodes dynamically). Step 1b's refinement pass would fall back to treating unmatched code as prose, which is a lossy default. Worth corpus-testing.
+- **§4 mapping table** translates graph structure to sequential/branching Python. The semantic translation is straightforward for linear flows; for complex control flow (many `Command(goto=...)` with state-dependent targets, or deeply nested conditional edges), the translation could become unreadable. Worth a worked example with a non-trivial graph.
+- **§6b custom reducers** — v1 doesn't reproduce them. For a spec where a custom reducer is load-bearing (e.g., a set-union reducer that deduplicates), the translation is incorrect. Worth making this a hard warning, not just "listed in not-reproduced."
+- **§6e subgraph inlining at 5-node threshold** is a guess. Real corpus data may show the right threshold is 3 or 10. Also, subgraphs that are reused multiple times (once as a node in graph A, once as a node in graph B) shouldn't be inlined at all — they're sharing, which inlining would duplicate. Worth revisiting.
+- **§5b OSS vs Platform modalities** handles Platform-only features cleanly but the SETUP.md §6/§7 message is generic. Real LangGraph users targeting Platform may want more specific guidance (which exact Platform features they're giving up by using melleafy). Worth detailed SETUP.md templates per Platform feature.
+- **`source_lines` format proliferation** (`py:`, `json:`, `frontmatter.`) now has three variants. Formalising as a structured `source_range: {"format": "line_range" | "json_path" | "frontmatter_field" | "py_function", "value": "..."}` is probably the right fix in Step 1b's next iteration. Cross-dialect cleanup item.
+- **Syntax error handling** (§3b) — a syntax error in the primary spec file is essentially unrecoverable in v1. Worth considering whether melleafy should suggest `black` or `ruff --fix` as a pre-processing step for near-valid files.

--- a/docs/dialects/letta.md
+++ b/docs/dialects/letta.md
@@ -1,0 +1,323 @@
+# Letta / MemGPT Dialect
+
+**Version**: 1.0.0
+**Status**: Second dialect doc; stress-tests the OpenClaw template against a single-file-JSON runtime.
+
+**Prerequisite reading**: `spec.md` R1 (detection), R22 (dialect mapping contract), R21 (modality); `plans/dialects/openclaw.md` (reference template); `plans/generated-package-shape.md` (what the output looks like).
+
+---
+
+## What this document does
+
+Describes the concrete rules melleafy applies when processing a **Letta** (formerly MemGPT) source spec. Letta is architecturally unusual among the surveyed runtimes: rather than a workspace of Markdown files, a Letta spec is primarily a single JSON document — the `.af` (Agent File). This dialect doc therefore adapts the template for a single-file-with-structured-content runtime.
+
+Key Letta concepts readers should have in mind:
+
+- **Agent File (`.af`)**: JSON-serialised agent state, Apache-2.0 licensed, secrets nulled on export.
+- **Core memory blocks**: typed memory with 2,000-character limits per block — `persona` and `human` are default; others can be added.
+- **Archival memory**: agent-immutable vector-store-backed knowledge, *not serialised into `.af` today* (Letta roadmap item).
+- **Tools**: carry `source_code`, `json_schema`, `pip_requirements`, `npm_requirements`.
+- **Sleep-time agents**: a second agent running in parallel that shares memory blocks, consolidating them every N primary-agent steps.
+
+---
+
+## 1. Detection signals
+
+Step 0 classifies a spec as Letta when any of the following is present in the workspace:
+
+| Signal | Strength | Notes |
+|---|---|---|
+| `*.af` file in workspace root | strong | The defining artefact — JSON with Letta-specific top-level keys |
+| `letta.config.yaml` file | strong | Workspace config; only Letta uses this name |
+| Spec body references `persona` or `human` blocks (memory-block vocabulary) | medium | Disambiguates from other JSON agent formats |
+| Spec body references `archival_memory_insert` / `archival_memory_search` | medium | Letta-specific tool names |
+| Spec body references `sleep-time agent` or `enable_sleeptime` | strong | Only Letta has this architecture |
+| Spec body references `request_heartbeat` as a tool parameter | medium | Legacy MemGPT signal; deprecated in `letta_v1_agent` but still in many older specs |
+| `agent_type: "memgpt_agent"` or `"letta_v1_agent"` in the `.af` | strong | Explicit agent type declaration |
+| Mention of LETTA_PG_URI, LETTA_SERVER_PASSWORD, or LETTA_ENCRYPTION_KEY | medium | Server-side env vars identify a Letta deployment |
+
+**Precedence note.** Letta signals are highly distinctive — the `.af` file alone is unambiguous. Unlike OpenClaw (where `AGENTS.md` can be confused with Claude Code), Letta has no file-name collisions with other runtimes in the v1 supported set.
+
+**Hybrid threshold.** If Letta signals are within 1 of another runtime's signals, `Hybrid` applies per R1. In practice the most likely hybrid pairing is Letta + Claude Code (a project that uses Claude Code as its dev environment while targeting Letta at runtime); both runtimes' inventory rules should then apply.
+
+---
+
+## 2. File inventory rules (Step 1a)
+
+**Letta's main source is a single JSON file — not a workspace of Markdown files.** Section 2 therefore differs in shape from the OpenClaw template: instead of listing per-file rules, it lists per-top-level-key rules within the `.af` document, plus a small set of sibling files when present.
+
+### 2a. Primary file — the `.af` (Agent File)
+
+The `.af` file is parsed once; every inventory rule below operates on a JSON path into the parsed structure.
+
+| JSON path | Role in spec | Inventory action |
+|---|---|---|
+| `agent_type` | Determines agent architecture (`memgpt_agent` vs `letta_v1_agent` vs `voice_convo_agent`) | Single element; drives modality classification |
+| `core_memory.blocks[].label == "persona"` | Persona text — C1 Identity | Block value becomes one element; `block.description` and `block.limit` become metadata |
+| `core_memory.blocks[].label == "human"` | User context — C3 User facts | Same shape as persona |
+| `core_memory.blocks[]` (other labels) | Custom memory blocks — C1 or C3 depending on purpose | Element per block; category inferred from `description` field |
+| `tools[]` | Tool definitions — C6 Tools | One element per tool; includes `source_code`, `json_schema`, `pip_requirements`, `npm_requirements` |
+| `tool_rules[]` | Constraints on tool invocation order — C2 Operating rules | Element per rule |
+| `model_config` | LLM config (model name, temperature, etc.) — C8 Runtime env | Single element |
+| `messages[]` | Conversation history | **Not inventoried** — conversation history is not a spec element |
+| `embedding_config` | Embedding model config — C8 Runtime env | Single element |
+| `enable_sleeptime` / `sleeptime_agent_frequency` | Sleep-time agent config — C9 Scheduling | Element per field; drives heartbeat modality |
+| `block_ids[]` | Shared memory references to other agents | Element; flagged as **cross-agent reference** (v1 doesn't reproduce) |
+
+### 2b. Sibling files
+
+Files alongside the `.af` that may also be read:
+
+| File | Role | Inventory action |
+|---|---|---|
+| `letta.config.yaml` | Server-side config | Parse YAML; contents become C8 runtime env elements |
+| `.env` or `.env.example` | Environment variables — C7 Credentials | Parse; one element per var. **Rule: Letta `.env` values must be unquoted (issue #3069).** Preserve verbatim |
+| `README.md` (if present) | Free-form notes about the agent | Treat as prose — NO_DECOMPOSE unless the spec body references it directly |
+
+### 2c. Memory block character limit
+
+Core memory blocks have a hard limit of **2,000 characters** per block. This is the Letta documentation's figure (and issue #7 confirms it); a widely-repeated 5,000-char number is from third-party content and is incorrect.
+
+When a block's `value` exceeds its `limit` field (typically 2,000 but user-configurable), Letta truncates at runtime. Melleafy:
+
+1. Inventories the full content regardless.
+2. Emits a warning in the mapping report's "Conflicts flagged during inventory" section.
+3. Does not truncate — same policy as OpenClaw's oversize files per Constitution Article 3 (source fidelity).
+
+### 2d. Archival memory is NOT in the `.af`
+
+Letta's archival memory (pgvector-backed) is **agent-immutable** and **not serialised into `.af` today** (Letta roadmap). If the spec body implies archival use — references to `archival_memory_insert`, `archival_memory_search`, or describes accumulating knowledge across sessions — melleafy infers a C5 Long-term memory dependency even without a corresponding `.af` field. The dependency is always `delegate_to_runtime` (no native Mellea backend).
+
+### 2e. Missing files
+
+Absence rules:
+
+- `.af` file absent: this is the defining Letta signal; if auto-detection said "Letta" but no `.af` exists, Step 0's detection was wrong — halt with a diagnostic asking for source-runtime override or `.af` file.
+- `letta.config.yaml` absent: normal; not every Letta spec has one.
+- `.env` / `.env.example` absent: normal; credentials may come from server-side config.
+
+---
+
+## 3. Frontmatter / structured-content rules
+
+**Letta has no Markdown frontmatter.** The `.af` file is structured JSON throughout. The template's Section 3 becomes "JSON content rules" for Letta.
+
+### 3a. JSON parsing
+
+`.af` files are parsed with `json.loads`. Parse failure halts Step 1a with a pointer to the offending line/column (standard `json.JSONDecodeError` output). Unlike OpenClaw's Markdown files, there's no "parse as free-form Markdown" fallback — if the JSON is malformed, there's no recovery.
+
+### 3b. Schema validation
+
+Letta publishes no formal `.af` JSON Schema (as of v1). Melleafy uses a **permissive parse**: required top-level keys are `agent_type` and `core_memory`; everything else is optional. Unknown top-level keys are preserved and surfaced in the mapping report's "Detected but not handled" section.
+
+### 3c. Secrets are nulled on export
+
+Letta's `.af` export convention nulls secrets (API keys, tokens) before writing. A `.af` file received from a colleague should never contain real credentials — they're referenced by env-var name but the values are `null`. Melleafy preserves this invariant: when generating `.env.example`, melleafy reads the env-var names from the `.af` but never expects the values to be populated.
+
+### 3d. `.af` version field
+
+The file may carry a `version` field naming the Letta schema version that produced it. If present, melleafy records it in the mapping report's Classification section for traceability. If the field names a version melleafy hasn't tested against, emit a warning; generation proceeds.
+
+---
+
+## 4. Dialect mapping table
+
+| Source signal | Category | Default disposition | Generation target |
+|---|---|---|---|
+| `core_memory.blocks[label="persona"].value` | C1 | `bundle` (if ≤2,000 chars) | `config.PREFIX_TEXT`; inlined as `prefix=` on all `m.instruct()` calls |
+| `core_memory.blocks[label="persona"].value` (oversize) | C1 | `bundle` with warning | Same; warning in mapping report |
+| `core_memory.blocks[label="human"].value` | C3 | `bundle` | `config.USER_CONTEXT`; default at generation time |
+| `core_memory.blocks[other]` with description naming user-overridable content | C3 | `external_input` | Pipeline parameter via `main.py` |
+| `core_memory.blocks[other]` with description naming agent-internal state | C4 | `delegate_to_runtime` | `constrained_slots.py:recall_block(<label>)` stub; SETUP.md §4 |
+| `tools[].source_code` (Python, described concretely) | C6 | `real_impl` | `tools.py:<tool_name>` |
+| `tools[].json_schema` without `source_code` | C6 | `stub` | `constrained_slots.py:<tool_name>` stub; SETUP.md §8 documents the required signature |
+| `tools[].source_code` (TypeScript) | C6 | `stub` | v1 melleafy does not generate TS; recorded as `delegate_to_runtime` with SETUP.md note |
+| `tool_rules[]` (ordering / validation rules) | C2 | `bundle` | `requirements.py:OPERATING_REQUIREMENTS` entry |
+| `tools[].pip_requirements` | C8 | `bundle` | Appended to `pyproject.toml:dependencies` |
+| `tools[].npm_requirements` | C8 | *(not reproduced)* | Listed in mapping report's "Runtime-specific constructs not reproduced" |
+| `model_config.model` | C8 | `bundle` | `config.MODEL_NAME` constant; SETUP.md §3 notes how to configure the Mellea backend to match |
+| `embedding_config.embedding_model` | C8 | `delegate_to_runtime` | Only needed if C5 archival is used; SETUP.md §5 |
+| `enable_sleeptime: true` | C9 | `delegate_to_runtime` | `config.SCHEDULE_CONFIG`; SETUP.md §6; modality = `heartbeat` |
+| `sleeptime_agent_frequency` | C9 | `delegate_to_runtime` | Populates `config.SCHEDULE_CONFIG.cadence` with "every N primary-agent steps" — not wall-clock time |
+| `tools[].request_heartbeat: true` (legacy MemGPT) | — | *(not reproduced)* | Listed in "Runtime-specific constructs not reproduced"; deprecated in `letta_v1_agent` |
+| Spec body references `archival_memory_insert` / `archival_memory_search` (no `.af` field) | C5 | `delegate_to_runtime` | `constrained_slots.py:archival_insert`, `archival_search`; SETUP.md §5 |
+| `block_ids[]` (shared memory with other agents) | — | *(deferred)* | Listed in Provenance appendix's "Detected but not handled" — cross-agent memory sharing is a Deferred Item |
+| `messages[]` (conversation history) | — | `remove` | Not reproduced; conversation history is not spec content |
+| `agent_type: "memgpt_agent"` | — | informational | Recorded in mapping report; drives some downstream modality decisions |
+| `agent_type: "letta_v1_agent"` | — | informational | Same |
+| `agent_type: "voice_convo_agent"` | — | informational | Drives modality = `realtime_media` |
+| `LETTA_PG_URI`, `LETTA_SERVER_PASSWORD`, `LETTA_ENCRYPTION_KEY` in env | C7 | `external_input` | `.env.example`; SETUP.md §2 |
+| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `E2B_API_KEY` in env | C7 | `external_input` | Same — declared even if not directly referenced in `.af` |
+
+**Override semantics.** Default dispositions are overridable via `--dependencies=ask` or `--dependencies=config:<path>` per the standard R22 contract.
+
+---
+
+## 5. Modality signals (Step 0 Axis 5, R21)
+
+Letta has the second-strongest modality-declaration surface after OpenClaw — explicit fields in the `.af` determine modality deterministically.
+
+| Signal | Modality classification |
+|---|---|
+| `enable_sleeptime: true` | **`heartbeat`** — state-aware periodic invocation via sleep-time agent |
+| `agent_type: "voice_convo_agent"` | **`realtime_media`** — voice-first bidirectional audio |
+| `agent_type: "memgpt_agent"` or `"letta_v1_agent"` with no sleep-time | **`conversational_session`** — Letta's default model ("the agent is the state"; clients don't pass history) |
+| Spec describes `POST /v1/agents/{id}/schedule` usage | **`scheduled`** — wall-clock cron scheduled via Letta API |
+| None of the above | **`conversational_session`** — Letta's implicit default even without explicit flags |
+
+**Composition.** Letta specs can simultaneously declare `conversational_session` (default) and `heartbeat` (via sleep-time) — a primary agent in conversation with a user while a sleep-time agent consolidates memory in the background. When both apply, `conversational_session` is primary and `heartbeat` is secondary. `scheduled` with `heartbeat` is also possible but unusual — flag for manual review per R21 composition rules.
+
+**Generated shape per R21.** Letta's default `conversational_session` is **Mellea-native** — it emits to shape §5c (`def run_pipeline(session: MelleaSession, message: str) -> str`). `heartbeat` and `scheduled` are host-needing; they fall back to synchronous_oneshot shape with SETUP.md §6/§7 guidance. `realtime_media` is also host-needing (requires LiveKit / Deepgram / Retell integration).
+
+### 5a. `request_heartbeat` — NOT a modality
+
+Legacy MemGPT's per-tool `request_heartbeat` parameter is sometimes confused with Letta sleep-time heartbeats but is architecturally different — it's an **intra-turn control signal** that schedules the next model step, not an external cadence. It's deprecated in `letta_v1_agent`. Melleafy records `request_heartbeat: true` tool settings in the mapping report but does not reproduce them; the generated pipeline uses Mellea's native control flow.
+
+---
+
+## 6. Quirks and workarounds
+
+### 6a. Archival memory absence in `.af`
+
+The biggest Letta-specific quirk: specs that clearly depend on archival memory (the spec body says "search across past sessions," "accumulate knowledge over time") often have NO corresponding field in the `.af` because archival passages aren't serialised there. Melleafy handles this by:
+
+1. Inspecting the spec body / description text for archival-memory vocabulary.
+2. Inferring a C5 dependency even without an `.af` field.
+3. Marking it with `source_of_decision: "inferred"` in the dependency plan.
+4. Surfacing prominently in the mapping report: "Archival memory inferred from spec body; `.af` file does not contain archival passages."
+
+This is the only place in the Letta dialect where dependency detection relies on inference rather than structured fields.
+
+### 6b. Sleep-time frequency is NOT wall-clock time
+
+Letta's `sleeptime_agent_frequency` is expressed as "every N primary-agent steps" — not minutes, not cron expressions. A value of `5` means "after every 5 messages the primary agent processes." This is a fundamentally different trigger model from wall-clock scheduling.
+
+Melleafy preserves this in `config.SCHEDULE_CONFIG`:
+
+```python
+SCHEDULE_CONFIG: Final[dict] = {
+    "cadence": "every-5-primary-steps",  # Letta-specific; not a cron expression
+    "source": "letta_sleeptime",
+}
+```
+
+SETUP.md §6 explains that a host adapter must count primary-agent steps (not wall-clock time) to correctly dispatch the sleep-time agent. This limits host-adapter options — plain `cron` or APScheduler can't implement this without additional state.
+
+### 6c. `.af` file size can be very large
+
+Unlike OpenClaw's bootstrap files (20K per file limit), Letta `.af` files can be large — particularly when tool `source_code` is serialised inline and there are many tools. A production Letta agent's `.af` can approach 1 MB. Step 1a's 10 MB per-file cap accommodates this; no Letta-specific limit.
+
+### 6d. Secret-nulling on export
+
+When a `.af` file is exported from Letta, secrets are nulled to prevent leakage. Melleafy must preserve this invariant: any `null`-valued credential field is treated as "value is set at runtime from env" rather than "value is literally null." The consistency lint in `plans/lints/melleafy-json-consistency.md` should flag a package that bundles a non-null credential value that traces back to a `null` `.af` field.
+
+### 6e. `tool_rules[]` vs `tools[].default_requires_approval`
+
+Letta has two distinct concepts that look similar:
+
+- `tool_rules[]` — top-level list of constraints on how tools are invoked (ordering, preconditions)
+- `tools[].default_requires_approval` — per-tool boolean for approval-gated invocation
+
+The first is C2 Operating rules (bundled as Requirements). The second is a C6 Tool attribute with a modality implication (`review_gated` as secondary). Melleafy distinguishes these in inventory:
+
+- `tool_rules[]` rows → elements tagged `DECIDE` or `VALIDATE_OUTPUT`, category C2
+- `default_requires_approval: true` → element tagged `CONVERSE` (since approval implies human input), category C6, with secondary modality `review_gated`
+
+### 6f. Inter-agent messaging tools
+
+Letta's `send_message_to_agent_async`, `send_message_to_agent_and_wait_for_reply`, and `send_message_to_agents_matching_all_tags` are cross-agent delegation primitives. v1 melleafy does not generate cross-agent call code — these are recorded as Deferred in the Provenance appendix. The corresponding tool declarations in `.af` are inventoried (they're tools) but their dispositions become `stub` with SETUP.md documenting that cross-agent wiring is a v2 candidate.
+
+---
+
+## 7. Reference inventory output (illustrative)
+
+For a minimal Letta spec with a `.af` file containing persona, human, one tool, and `enable_sleeptime: true`:
+
+### Inventory (abridged)
+
+```json
+{
+  "elements": [
+    {"element_id": "elem_001", "source_file": "agent.af", "source_lines": "json:core_memory.blocks[0]", "tag": "CONVERSE", "category": "C1", "content_summary": "Persona: helpful research assistant"},
+    {"element_id": "elem_002", "source_file": "agent.af", "source_lines": "json:core_memory.blocks[1]", "tag": "CONFIG", "category": "C3", "content_summary": "Human: Alice, researcher at Acme Labs"},
+    {"element_id": "elem_015", "source_file": "agent.af", "source_lines": "json:tools[0]", "tag": "TOOL_TEMPLATE", "category": "C6", "content_summary": "search_papers tool (Python, real_impl)"},
+    {"element_id": "elem_042", "source_file": "agent.af", "source_lines": "json:enable_sleeptime + sleeptime_agent_frequency", "tag": "ORCHESTRATE", "category": "C9", "content_summary": "Sleep-time agent every 5 primary-agent steps"}
+  ]
+}
+```
+
+Note the `source_lines` convention: for JSON paths, the format is `"json:<jq-style-path>"` rather than line ranges. This is a dialect-specific extension of the standard `source_lines` format. Step 1b is aware of this convention and surfaces it faithfully in the mapping report.
+
+### Element mapping (abridged)
+
+```json
+{
+  "mappings": [
+    {"element_id": "elem_001", "target_file": "config.py", "target_symbol": "PREFIX_TEXT", "primitive": "bundle"},
+    {"element_id": "elem_002", "target_file": "config.py", "target_symbol": "USER_CONTEXT", "primitive": "bundle"},
+    {"element_id": "elem_015", "target_file": "tools.py", "target_symbol": "search_papers", "primitive": "real_impl"},
+    {"element_id": "elem_042", "target_file": "config.py", "target_symbol": "SCHEDULE_CONFIG", "primitive": "delegate"}
+  ]
+}
+```
+
+### Dialect-specific notes in the mapping report
+
+For a Letta spec, the mapping report's Provenance appendix includes:
+
+- A "Runtime-specific constructs not reproduced" section listing `npm_requirements`, `request_heartbeat`, cross-agent `block_ids`.
+- An "Archival memory inference" note if C5 was inferred from spec body rather than `.af` fields.
+- A note on the sleep-time cadence: "Cadence is expressed as primary-agent steps, not wall-clock time. Host adapter must track step counts."
+
+---
+
+## 8. Deferred Letta features (not handled in v1)
+
+- **Archival memory full serialisation.** When Letta adds archival passages to `.af` (roadmap), melleafy's C5 inference (§6a) becomes unnecessary — the passages can be read directly.
+- **Cross-agent memory sharing via `block_ids`.** v1 records but does not reproduce.
+- **Inter-agent messaging tools** (`send_message_to_agent_async`, etc.). v1 stubs; v2 could generate delegation scaffolding.
+- **TypeScript tools** (`tools[].source_code` with TS language). v1 doesn't generate TS; flagged as not reproduced.
+- **`auth-profiles.json`** — Letta's credential store format. v1 doesn't parse; users manage credentials via env.
+- **Letta native voice** (`voice_convo_agent` agent type). v1 classifies as `realtime_media` modality and stubs; v2 could generate LiveKit-compatible wrappers.
+- **Letta-native scheduling** (POST /schedule). v1 records as C9 delegate; v2 could emit a cron-scheduled wrapper.
+
+---
+
+## 9. Cross-references
+
+- `spec.md` R1, R21, R22 — the contracts this dialect implements
+- `spec.md` Deferred Items — harness adapter, native memory backend (both particularly relevant for Letta)
+- `plans/dialects/openclaw.md` — template this dialect adapts
+- `plans/generated-package-shape.md` — what the generated package looks like
+- `glossary.md` — `dialect`, `disposition`, `interaction modality`
+- `melleafy.json` schema — the manifest fields this dialect populates
+
+---
+
+## 10. Ratification notes
+
+This dialect doc v1.0.0 was the second one drafted, selected deliberately to stress-test the OpenClaw template against a fundamentally different source-runtime shape (single JSON file vs. Markdown workspace).
+
+**What the template survived unchanged:**
+- Section 1 (Detection signals) — worked identically
+- Section 4 (Dialect mapping table) — the four-column shape is runtime-agnostic; the "source signal" column became JSON paths instead of file references
+- Section 5 (Modality signals) — runtimes express modality differently but the axis structure is fixed
+- Sections 6–10 — shape translated directly
+
+**What the template needed to adapt:**
+- Section 2 (File inventory) — became "JSON path inventory inside the `.af`" instead of "files in workspace." The underlying intent (name every source surface inventoried) is preserved; the structure is different.
+- Section 3 (Frontmatter) — "Markdown frontmatter" doesn't apply; replaced with "JSON parsing and structured-content rules."
+- Section 7 (Reference inventory output) — `source_lines` format extended to include a `"json:<path>"` convention for JSON-derived elements.
+
+**What this tells us about the template's generality.** The template is a good fit for any runtime that has:
+(a) detectable signals, (b) a set of source surfaces from which elements are extracted, (c) a category-per-surface mapping, (d) modality declarations somewhere in the spec.
+
+Letta satisfies all four with a structurally different source format than OpenClaw, and the template accommodated that without restructuring. The other seven dialect docs (Claude Code, CrewAI, LangGraph, AutoGen, Agents SDK, smolagents, Hybrid, Agent Skills std) should all fit the same shape — they're mostly Markdown-file or Python-code workspaces, which are less unusual than Letta's JSON-file model.
+
+Open questions:
+
+- **The "json:<jq-path>" source_lines convention** (§7) is my invention. If we add more structured-file runtimes (e.g., any dialect targeting YAML-heavy configs), we should extend this formally — perhaps to `source_range: {"format": "json_path" | "line_range", "value": "..."}` in `inventory.json`. Worth formalising during Step 1b implementation.
+- **§6a archival memory inference** is the only place in Letta's dialect where inventory relies on text inspection rather than structured fields. This is brittle — keyword matching on "archival" or "across sessions" may miss or false-positive. An LLM-assisted inference would be more robust but reintroduces KB 5 risk. Flagged for revisit if the heuristic proves inadequate.
+- **§6b sleep-time frequency in steps, not time.** The `config.SCHEDULE_CONFIG.cadence: "every-5-primary-steps"` format needs corresponding recognition in the `melleafy.json` schema's `schedule_config` — the current schema has `interval`, `cron`, `event` variants but not "step-counted." Worth adding a fourth variant `step_counted` in a manifest_version 1.2.0, or treating Letta sleep-time as a special case of `interval` with unusual units.
+- **§2a `messages[]` exclusion.** I excluded conversation history from inventory because it's runtime state, not spec content. Worth confirming: are there Letta agent specs where `messages[]` encodes system-prompt-like context the user wants reproduced? If yes, we'd need a rule for "exclude unless the user explicitly opts in."
+- **Cross-agent `block_ids` and `send_message_to_agent_*`** are deferred but common. A Letta user writing a multi-agent spec will hit these on day one. Worth considering whether v1 should at least emit a SETUP.md section pointing at the v2 adapter work, rather than silently listing them as deferred.

--- a/docs/dialects/openclaw.md
+++ b/docs/dialects/openclaw.md
@@ -1,0 +1,269 @@
+# OpenClaw Dialect
+
+**Version**: 1.0.0
+**Status**: Reference template — other dialect docs should follow this shape
+
+**Prerequisite reading**: `spec.md` R1 (detection), R22 (dialect mapping contract), R21 (modality); `constitution.md` Articles 3, 7, 8, 13.
+
+---
+
+## What this document does
+
+Describes the concrete rules melleafy applies when processing an **OpenClaw** source spec. Covers detection (Step 0), file inventory (Step 1a), the four-column mapping table (R22), modality signals (R21), and runtime-specific quirks.
+
+When a future contributor wants to add a new source runtime, they write a dialect doc in this shape. When a future melleafy run encounters an OpenClaw spec, the code paths implementing each section below should point here.
+
+---
+
+## 1. Detection signals
+
+Step 0 classifies a spec as OpenClaw when any of the following signals are present in the workspace directory (the source spec's parent):
+
+| Signal | Strength | Notes |
+|---|---|---|
+| `SOUL.md` file | strong | Bootstrap file — highly distinctive |
+| `IDENTITY.md` file | strong | Bootstrap file |
+| `AGENTS.md` file | medium | Also used by some Claude Code conventions; the full OpenClaw set is what disambiguates |
+| `HEARTBEAT.md` file | strong | Only OpenClaw uses this filename |
+| `BOOTSTRAP.md` file | strong | Self-destructing first-run ritual; highly distinctive |
+| `MEMORY.md` + `memory/` directory | strong | The directory pattern is OpenClaw-specific |
+| `memory-wiki/` directory with `entities/`, `concepts/`, etc. | strong | OpenClaw wiki structure |
+| `~/.openclaw/` config path exists on disk | strong | Per-user OpenClaw installation |
+| `openclaw.json` with `agents.defaults.heartbeat` | strong | Workspace-level config |
+| `TOOLS.md` + `USER.md` + `AGENTS.md` triad | medium | Partial bootstrap set |
+
+**Precedence note.** Because OpenClaw reuses the `AGENTS.md` filename, single-signal detection on `AGENTS.md` alone is insufficient. Classification as OpenClaw requires at least one *strong* signal, or two *medium* signals. If only `AGENTS.md` matches (no stronger signals), classification defaults to Claude Code per the R1 precedence ordering (Claude Code > OpenClaw when tied).
+
+**Hybrid threshold.** If OpenClaw signal count is within 1 of another runtime's signal count, classification is `Hybrid` per R1 and both runtimes' inventory rules run; the user should override if they know better.
+
+---
+
+## 2. File inventory rules (Step 1a)
+
+When classification is OpenClaw, Step 1a reads the following files from the workspace:
+
+### 2a. Bootstrap files
+
+| File | Role in spec | Inventory action |
+|---|---|---|
+| `SOUL.md` | Persona, values, tone (C1 Identity) | Read entire content; split into elements per heading |
+| `IDENTITY.md` | External presentation — name, role, emoji, avatar (C1 Identity) | Read entire content; each field becomes an element |
+| `AGENTS.md` | Operating rules (C2) | Read content; each rule / directive becomes an element |
+| Scoped `docs/AGENTS.md`, `ui/AGENTS.md` | Directory-scoped operating rules (C2) | Read if present; elements tagged with scope |
+| `USER.md` | User facts (C3) | Read content; each fact becomes an element |
+| `TOOLS.md` | Tool guidance (C6, doc-only) | Read content — this is *narrative about tools*, not tool definitions |
+| `MEMORY.md` | Long-term memory layout / conventions (C5) | Read content; elements describe the memory structure |
+| `HEARTBEAT.md` | Scheduling (C9) | Read content; cadence declarations become elements |
+| `BOOTSTRAP.md` | First-run ritual (self-destructs) | Note presence; **do not bundle into generated code** (disposition: `remove` with rationale) |
+
+### 2b. Memory / runtime state files
+
+| Path | Role | Inventory action |
+|---|---|---|
+| `memory/YYYY-MM-DD.md` (today + yesterday) | Daily logs (C4 Short-term state) | Inventory the *file existence*, not contents — content is ephemeral and not bundled |
+| `memory-wiki/entities/` | Entity notes (C5) | Inventory file list; element per file with frontmatter parsed |
+| `memory-wiki/concepts/` | Concept notes (C5) | Same as entities |
+| `memory-wiki/syntheses/` | Synthesis notes (C5) | Same |
+| `memory-wiki/sources/` | Source notes (C5) | Same |
+| `memory-wiki/_views/` | View definitions (C5) | Inventory — these are often generated |
+
+### 2c. Config
+
+| File | Role | Inventory action |
+|---|---|---|
+| `openclaw.json` (workspace level) | Agent config including `heartbeat.*` fields | Parse JSON; heartbeat config becomes C9 element |
+| `~/.openclaw/` | User-level config | Do not read; note existence as detection signal only |
+
+### 2d. Character limits and truncation
+
+**Per-file limit**: 20,000 characters per bootstrap file.
+**Aggregate budget**: 150,000 characters across all bootstrap files.
+
+OpenClaw silently truncates files that exceed the per-file limit. When melleafy detects a file over 20,000 chars, it emits a **warning** (not a fatal error) and records the detection in the mapping report's "Conflicts flagged during inventory" section. Generation proceeds with the full content; if the content is used as `prefix=` text per the mapping table below, generation also emits a runtime warning that the OpenClaw runtime would have truncated it.
+
+### 2e. Missing-file markers
+
+OpenClaw injects a placeholder when a bootstrap file is absent. A missing file is **not an error**; inventory simply records it as absent. The only time absence becomes a problem is when the spec body explicitly references a missing file — that's a spec-author bug and melleafy records it in the mapping report but proceeds.
+
+---
+
+## 3. Frontmatter rules
+
+**OpenClaw bootstrap files generally have no YAML frontmatter.** Parse them as free-form Markdown. Two exceptions:
+
+1. `memory-wiki/*/*.md` files may have `claims:` frontmatter — a list of structured assertions. Parse if present.
+2. `openclaw.json` is JSON, not Markdown with frontmatter; its field layout is the authoritative schema.
+
+When generating a Mellea pipeline from an OpenClaw source, melleafy does **not** emit an OpenClaw-style `openclaw.json` — the generated pipeline is target-neutral Mellea Python. OpenClaw-specific config that would be needed to redeploy the pipeline back into OpenClaw is emitted as a SETUP.md section under "Host adapter — OpenClaw."
+
+---
+
+## 4. Dialect mapping table
+
+This is the R22 contract: source signal → dependency category → default disposition → generation target.
+
+| Source signal | Category | Default disposition | Generation target |
+|---|---|---|---|
+| `SOUL.md` body (persona, voice) | C1 | `bundle` | `config.PREFIX_TEXT`; inlined as `prefix=` argument to all `m.instruct()` calls |
+| `IDENTITY.md:name` | C1 | `bundle` | `config.AGENT_NAME` constant |
+| `IDENTITY.md:role` | C1 | `bundle` | `config.AGENT_ROLE` constant |
+| `IDENTITY.md:emoji`, `IDENTITY.md:avatar` | C1 | `bundle` | `config.AGENT_METADATA` dict |
+| `AGENTS.md` individual rule | C2 | `bundle` | Entry in `requirements.py:OPERATING_REQUIREMENTS` + prompt-text inline in relevant `m.instruct()` calls |
+| Scoped `docs/AGENTS.md` | C2 | `bundle` | Prompt-text applied only in `m.instruct()` calls tagged for docs context |
+| `USER.md:stable_fact` | C3 | `bundle` | `config.USER_CONTEXT` constant |
+| `USER.md:overridable_fact` | C3 | `external_input` | Pipeline parameter `--user-context` on `main.py`; default from USER.md |
+| `TOOLS.md` narrative about a tool | C6 | `bundle` (doc only; does not grant permissions) | Prompt text appended to the relevant tool's `m.instruct()` context |
+| `MEMORY.md` body | C5 | `delegate_to_runtime` | `constrained_slots.py:recall_memory` stub; SETUP.md §5 (Long-term memory backend) |
+| `memory/YYYY-MM-DD.md` daily log | C4 | `delegate_to_runtime` | `constrained_slots.py:load_working_state` stub; SETUP.md §4 (Short-term state backend) |
+| `memory-wiki/entities/*.md` with `claims:` frontmatter | C5 | `delegate_to_runtime` | Stub + SETUP.md §5.1 (Wiki-structured memory); if present, emit a Known-Issue note about `claims:` parsing not being part of v1 |
+| `HEARTBEAT.md` body | C9 | `delegate_to_runtime` | `config.SCHEDULE_CONFIG`; SETUP.md §6 (External scheduler); modality sets to `heartbeat` (R21) |
+| `openclaw.json:heartbeat.every` | C9 | `delegate_to_runtime` | `config.SCHEDULE_CONFIG:cadence`; also drives `melleafy.json:schedule_config.type=interval` |
+| `openclaw.json:heartbeat.activeHours` | C9 | `delegate_to_runtime` | `config.SCHEDULE_CONFIG:active_hours`; SETUP.md §6.1 notes "Mellea pipeline has no day-gating; wrap invocation in the scheduler" |
+| `openclaw.json:heartbeat.lightContext` | C9 | *(not reproduced)* | Listed in mapping report's "Runtime-specific constructs not reproduced" — Mellea always passes full context |
+| `openclaw.json:heartbeat.isolatedSession` | C9 | *(not reproduced)* | Same — Mellea has no equivalent session isolation policy |
+| `BOOTSTRAP.md` presence | — | `remove` | Listed in mapping report's "Removed during audit" table with rationale: "BOOTSTRAP.md is a one-shot first-run ritual that self-destructs; not reproduced in generated pipeline" |
+| `agents.list[]` entry (another agent in workspace) | C2 | *(deferred)* | Listed in Provenance appendix's "Detected but not handled" — cross-agent delegation is a Deferred Item |
+
+**Override semantics.** Every row shows the *default* disposition. Any row can be overridden via `--dependencies=ask` elicitation or a `--dependencies=config:<path>` pre-authored decisions file. Overrides are recorded with `source_of_decision: "user"` in `dependency_plan.json` and `melleafy.json:categories_resolved`.
+
+---
+
+## 5. Modality signals (Step 0 Axis 5, R21)
+
+OpenClaw has the strongest modality signal of any surveyed runtime: the `openclaw.json:heartbeat.*` block.
+
+| Signal | Modality classification |
+|---|---|
+| `openclaw.json:heartbeat.every` present (e.g., `"30m"`, `"1h"`) | **`heartbeat`** — state-aware periodic self-invocation |
+| `HEARTBEAT.md` present with cadence declaration in body | **`heartbeat`** — same |
+| `HOOK.md` file present or `openclaw.json:hooks[]` entries | **`event_triggered`** — external event fires the agent |
+| `openclaw cron add` invocations mentioned in workspace | **`scheduled`** (distinct from `heartbeat` — no state-aware skipping) |
+| Neither heartbeat, hooks, nor cron present | **`synchronous_oneshot`** (default) |
+
+**Composition.** OpenClaw specs can declare `heartbeat` + `event_triggered` simultaneously (the HEARTBEAT wakes on a cadence but can also be triggered via `openclaw system event --text "..." --mode now`). When both are detected, `heartbeat` is recorded as primary and `event_triggered` as secondary in `classification.json`.
+
+**Generated shape per R21.** All OpenClaw heartbeat specs classify as host-needing modalities, so the generated Python is `synchronous_oneshot`-shaped (`run_pipeline()` callable), with:
+
+- `config.SCHEDULE_CONFIG` populated with the detected cadence
+- `melleafy.json:modality: "heartbeat"` (or `"event_triggered"`, or both)
+- SETUP.md §6 naming candidate host adapters: APScheduler + SQLite (custom), or redeploying into OpenClaw itself via `agents.defaults.heartbeat` config
+
+---
+
+## 6. Quirks and workarounds
+
+### 6a. BOOTSTRAP.md self-destructs
+
+Source specs frequently reference BOOTSTRAP.md content in the main spec body ("as established in BOOTSTRAP.md..."). After the first OpenClaw run, BOOTSTRAP.md is deleted, so references to it are references to content that no longer exists at runtime. Melleafy handles this by:
+
+1. Reading BOOTSTRAP.md during inventory (treating it as present).
+2. Inlining any BOOTSTRAP.md content the spec body references into the relevant C1/C2 generated target (SOUL persona, AGENTS rules).
+3. Marking BOOTSTRAP.md with `disposition: remove` in the dependency plan — it doesn't become its own bundled artifact.
+4. Recording the inlining decision in the mapping report's "Runtime-specific constructs not reproduced."
+
+### 6b. `activeHours` is not generatable in Mellea
+
+OpenClaw's `heartbeat.activeHours` (e.g., `09:00-18:00`) is a scheduler-level concern. Mellea has no day-gating primitive. This is not a failure — it's a limitation reflected in SETUP.md §6.1:
+
+> Your OpenClaw spec declared `activeHours: 09:00-18:00`. Mellea has no equivalent; the generated pipeline will run whenever its scheduler invokes it. Configure your scheduler (APScheduler, cron, OpenClaw itself) to respect active hours.
+
+The `melleafy.json:schedule_config.active_hours` field *does* preserve the declaration, so a v2 host-adapter tool can re-emit it into the target scheduler's native format.
+
+### 6c. `lightContext: true` is not generatable
+
+Mellea always passes full context to each session. OpenClaw's `lightContext` optimisation has no equivalent. Recorded in the mapping report's "Runtime-specific constructs not reproduced" section. Not a SETUP.md concern because it's an optimisation, not a correctness issue.
+
+### 6d. `memory-wiki/` wikilinks
+
+`memory-wiki/*/*.md` files use `[[wikilink]]` syntax for cross-references. Mellea has no wiki primitive. When a spec body references a specific wiki file, melleafy:
+
+1. Reads the referenced file and inventories its content.
+2. If the reference is for reading (the agent consults the wiki), maps to `C5 delegate_to_runtime` with a stub.
+3. If the reference is for writing (the agent updates the wiki), maps to `C5 delegate_to_runtime` with a stub *and* flags the operation as "side-effect on shared state" in the mapping report.
+
+Wikilink *rewriting* (changing `[[old-name]]` references when the target file is renamed) is a Deferred Item — v1 generates stubs that raise `NotImplementedError` on rewrite operations.
+
+### 6e. `claims:` frontmatter parsing
+
+Some `memory-wiki/*/*.md` files have structured `claims:` frontmatter (a YAML list of assertions). Parsing semantics — whether each claim is independent, whether they compose, how they're scoped — is not fully documented in OpenClaw's published spec. Melleafy v1 treats the `claims:` list as opaque metadata: it's preserved in the inventory and referenced in the mapping report, but the generated stub does not attempt to reason over it structurally. Full `claims:` support is a Deferred Item.
+
+### 6f. Heartbeat skip semantics
+
+OpenClaw heartbeats are *state-aware*: the agent reads `memory/YYYY-MM-DD.md` or similar state files and decides whether to act. The stated skip outcomes include `HEARTBEAT_OK` (no action needed) and various `reason=empty-heartbeat-file`, `reason=no-tasks-due` patterns.
+
+Melleafy's generated pipeline implements the cognition (decide whether to act) but not the skip mechanism itself — the SETUP.md §6 guidance explains that the host adapter is responsible for interpreting the pipeline's return value and translating skips into OpenClaw's wire protocol.
+
+---
+
+## 7. Reference inventory output (illustrative)
+
+For a minimal OpenClaw spec with SOUL.md, IDENTITY.md, AGENTS.md, and HEARTBEAT.md, the inventory and mapping outputs look like this:
+
+### Inventory (abridged)
+
+```json
+{
+  "elements": [
+    {"element_id": "elem_001", "source_file": "SOUL.md", "source_lines": "3-28", "tag": "CONVERSE", "category": "C1", "content_summary": "Warm, curious tone; prefers Socratic questioning"},
+    {"element_id": "elem_002", "source_file": "IDENTITY.md", "source_lines": "1", "tag": "CONFIG", "category": "C1", "content_summary": "name: ticket-triage"},
+    {"element_id": "elem_015", "source_file": "AGENTS.md", "source_lines": "5-7", "tag": "DECIDE", "category": "C2", "content_summary": "Rule: never auto-close a ticket without confirmation"},
+    {"element_id": "elem_042", "source_file": "HEARTBEAT.md", "source_lines": "1-5", "tag": "ORCHESTRATE", "category": "C9", "content_summary": "Run every 30m during business hours"}
+  ]
+}
+```
+
+### Element mapping (abridged)
+
+```json
+{
+  "mappings": [
+    {"element_id": "elem_001", "target_file": "config.py", "target_symbol": "PREFIX_TEXT", "primitive": "bundle", "mellea_construct": "prefix= argument on all m.instruct"},
+    {"element_id": "elem_002", "target_file": "config.py", "target_symbol": "AGENT_NAME", "primitive": "bundle", "mellea_construct": "constant"},
+    {"element_id": "elem_015", "target_file": "requirements.py", "target_symbol": "OPERATING_REQUIREMENTS", "primitive": "Requirement", "mellea_construct": "Requirement(description=..., validation_fn=...)"},
+    {"element_id": "elem_042", "target_file": "config.py", "target_symbol": "SCHEDULE_CONFIG", "primitive": "delegate", "mellea_construct": "constant + SETUP.md §6"}
+  ]
+}
+```
+
+### Dialect-specific notes in the mapping report
+
+The mapping report for an OpenClaw spec contains, in its Provenance appendix:
+
+- A "Runtime-specific constructs not reproduced" section listing `activeHours`, `lightContext`, `isolatedSession`.
+- A "Removed during audit" entry for BOOTSTRAP.md if present.
+- A "Detected but not handled (deferred)" section noting any `memory-wiki/` wikilinks, `claims:` frontmatter, or cross-agent `agents.list[]` references.
+
+---
+
+## 8. Deferred OpenClaw features (not handled in v1)
+
+Listed here so users whose OpenClaw specs exercise one of these know they're seen, not silently dropped.
+
+- **`claims:` frontmatter structured parsing.** v1 treats as opaque.
+- **`memory-wiki/` wikilink rewriting.** v1 stubs raise on rewrite operations.
+- **Cross-agent delegation via `agents.list[]`.** v1 records but does not generate cross-agent call code.
+- **OpenClaw `hooks` with handler.ts.** v1 classifies as `event_triggered` modality but does not emit the handler.ts itself — TypeScript emission is out of scope.
+- **OpenClaw-native host adapter.** v1 generates Mellea-neutral Python + SETUP.md guidance; a `melleafy export --host=openclaw` command that emits a ready-to-drop-in OpenClaw workspace is a v2 candidate.
+
+---
+
+## 9. Cross-references
+
+- `spec.md` R1, R21, R22 — the contracts this dialect implements
+- `spec.md` Deferred Items (harness adapter generation, native memory backend) — where OpenClaw features land that we don't handle in v1
+- `constitution.md` Article 3 (source fidelity), Article 13 (deferred features explicit)
+- `glossary.md` — `dialect`, `disposition`, `interaction modality`
+- `melleafy.json` schema — the manifest fields this dialect populates
+- Other dialect docs in `plans/dialects/` — their shape mirrors this one
+
+---
+
+## 10. Ratification notes
+
+This dialect doc v1.0.0 was drafted as the first concrete subsidiary of `plan.md`, and intentionally serves as the template for the other eight dialects. If its structure proves wrong during implementation, it needs revision *first*, before the other dialect docs are drafted against it.
+
+Open questions:
+
+- Section 2d character limits — are these current OpenClaw numbers or historical? Worth validating against the latest OpenClaw docs before finalising.
+- Section 4's mapping table is the core deliverable. Every row is a commitment. Any row that's wrong means v1 generates wrong code for that signal.
+- Section 6 quirks — are there OpenClaw-specific things we're missing? Likely yes; this is the section that will grow most as real specs are encountered.


### PR DESCRIPTION
 ## Issue                                                                                                           
                                                            
  Two `mellea-fy` sub-commands reference per-runtime dialect specifications at a path                               
  (`melleafy-handoff/plans/dialects/<runtime>.md`) that lives only in internal handoff documentation and does not
  ship in this repository. An external user running `melleafy run` against a CrewAI workspace, for example, hits a
  reference the public repo cannot satisfy; the workflow proceeds, but Steps 0, 1, and 2 lose dialect-specific      
  knowledge that the source spec assumes is available.
                                                                                                                    
  This PR ships the seven mature dialect specifications under `docs/dialects/` and updates the two sub-commands that
   reference the path. The contract `mellea-fy-inventory` and `mellea-fy-map` declare in their text is now
  resolvable inside this repo.
                                                                                                                    
  ## `docs/dialects/`
                                                                                                                    
  Dialect specifications are documentation, not Claude Code commands; co-locating them under `.claude/commands/`
  would overload that directory's purpose. `docs/dialects/` is also discoverable for users browsing the repo without
   Claude Code installed, and the path is short.
                                                                                                                    
  ## Files
                                                                                                                    
  **Added (8)**                                             
  - `docs/dialects/README.md` — entry point describing the directory's purpose, naming convention, shipped versus
  stubbed runtimes, and graceful fallback behaviour for unknown runtimes
  - `docs/dialects/agent-skills-std.md`   
  - `docs/dialects/claude-code.md`            
  - `docs/dialects/crewai.md`                                                                                       
  - `docs/dialects/hybrid.md` (rules for ambiguous runtime classifications)
  - `docs/dialects/langgraph.md`                                                                                    
  - `docs/dialects/letta.md`                                
  - `docs/dialects/openclaw.md`                                                                                     
                                                                                                                    
  **Edited (2)** — single search-and-replace per file: `melleafy-handoff/plans/dialects/<runtime>.md` →
  `docs/dialects/<runtime>.md`                                                                                      
  - `.claude/commands/mellea-fy-inventory.md`                                                                       
  - `.claude/commands/mellea-fy-map.md`                                                                             
                                                                                                                    
  `.claude/commands/mellea-fy-classify.md` is intentionally unchanged: it discusses dialect docs at the conceptual  
  level but does not reference the path explicitly.         
                                                                                                                    
  ## Verification                                                                                                   
                                                                                                                    
  ```bash                                                                                                           
  grep -rn "melleafy-handoff/plans/dialects" .              
  # expected: zero matches 