### PR TITLE
docs(mellea-fy): thread per-call input via user_variables + Jinja, no…

### DIFF
--- a/.claude/commands/mellea-fy-behaviours.md
+++ b/.claude/commands/mellea-fy-behaviours.md
@@ -237,17 +237,17 @@ Use `surrounding_context`, `finding_context`, `source_text`, `doc_context`, etc.
 from mellea.backends.model_options import ModelOption
 
 result = m.instruct(
-    "Analyse this security report.",
+    "Analyse this security report:\n{{ report }}",
+    user_variables={"report": str(report_text)},
     model_options={ModelOption.SYSTEM_PROMPT: PREFIX_TEXT},
-    grounding_context={"report": report_text},
     format=SecurityReport,
 )
 
 # WRONG — prefix= is an output prefix, not a system prompt
 result = m.instruct(
-    "Analyse this security report.",
+    "Analyse this security report:\n{{ report }}",
+    user_variables={"report": str(report_text)},
     prefix=PREFIX_TEXT,
-    grounding_context={"report": report_text},
     format=SecurityReport,
 )
 ```

--- a/.claude/commands/mellea-fy-generate.md
+++ b/.claude/commands/mellea-fy-generate.md
@@ -187,7 +187,8 @@ Apply this per-mode distinction at the call site in `pipeline.py` too: every bra
 - `with start_session(BACKEND, MODEL_ID) as m:` context manager
 - Calls slots, requirements, and mobjects from other files
 - `DECIDE` logic: Python `if/elif/else` wrapping Mellea calls
-- MUST convert all non-string `grounding_context` values to `str()`
+- MUST thread the user input / per-call value into `m.instruct(description=...)` via `user_variables` + a `{{ key }}` Jinja placeholder in the description text — e.g. `m.instruct("Classify: {{ user_query }} ...", user_variables={"user_query": str(user_query)}, ...)`. Reserve `grounding_context` for document or reference material the description text explicitly cites — that is the channel the docs reserve for it (see https://docs.mellea.ai/how-to/working-with-data, which pairs `user_variables={"query": ...}` with `grounding_context={"doc0": doc0, ...}`). The per-backend prompt template (e.g. `mellea/templates/prompts/granite/Instruction.jinja2`) renders the `grounding_context` block under the header *"Write the response by aligning with the facts and items in the following grounding context"* — that framing fits supporting documents, not the value the model must directly extract from or classify; with `format=PydanticModel` constrained decoding, putting the primary input there produces silent extraction failures.
+- MUST convert any non-string `grounding_context` value with `str()`.
 - MUST use `format=PydanticModel` for every `m.instruct()` that produces structured output
 - MUST parse the thunk after every `m.instruct(format=Model)` before accessing any field or calling any Pydantic method. `m.instruct()` returns a `ComputedModelOutputThunk` — NOT a Pydantic model. Direct field access (`thunk.field_name`) or `.model_dump()` raises `AttributeError`. Always include `_parse_instruct_result` and `_safe_parse_with_fallback` helpers in `pipeline.py` and call them immediately after every `m.instruct(format=Model)` call:
 
@@ -366,9 +367,10 @@ while not verdict.passed and remediation_count < MAX_REMEDIATION_ITERATIONS:
     # Modification step: generate a fix
     with start_session(BACKEND, MODEL_ID) as m_fix:
         fix = m_fix.instruct(
-            "Generate a minimal patch to address the identified issue.",
-            grounding_context={
-                "current_code": patched_code,
+            "Generate a minimal patch for this code:\n{{ current_code }}\n\n"
+            "Issue to address:\n{{ verdict }}",
+            user_variables={
+                "current_code": str(patched_code),
                 "verdict": str(verdict.model_dump()),
             },
             format=CodeFix,
@@ -382,8 +384,12 @@ while not verdict.passed and remediation_count < MAX_REMEDIATION_ITERATIONS:
     # Re-evaluation step
     with start_session(BACKEND, MODEL_ID) as m_eval:
         verdict = _parse_instruct_result(
-            m_eval.instruct("Re-evaluate...", grounding_context={"code": patched_code}, format=Verdict),
-            Verdict
+            m_eval.instruct(
+                "Re-evaluate this code:\n{{ code }}",
+                user_variables={"code": str(patched_code)},
+                format=Verdict,
+            ),
+            Verdict,
         )
 ```
 


### PR DESCRIPTION
 ## Summary

  - Update the `mellea-fy` slash-command directives to recommend `user_variables`
    + a `{{ key }}` Jinja placeholder in `description` as the channel for
    per-call input, instead of `grounding_context`.
  - `grounding_context` is reserved (per the Mellea docs) for documents /
    reference material the description text explicitly cites.
  - The `str()` rule for non-string `grounding_context` values is preserved; the
    existing `grounding-context-types` Step 7 lint continues to apply.

  ## Why

  The Mellea Instruction template (e.g.
  `mellea/templates/prompts/granite/Instruction.jinja2`) renders the
  `grounding_context` block under the header *"Write the response by aligning
  with the facts and items in the following grounding context"*. That framing
  makes the model treat grounding entries as **supporting context**, not as the
  value the model must directly extract from or classify. Under
  `format=PydanticModel` constrained decoding on smaller instruction-tuned
  models, putting the primary input there produces silent extraction failures:
  the schema is filled with `null`/default values because the model treats the
  description as the task and never references the grounding block.

  The Mellea docs' canonical pattern
  ([Working with Data](https://docs.mellea.ai/how-to/working-with-data)) pairs
  `user_variables={"query": ...}` (the per-call input) with
  `grounding_context={"doc0": doc0, ...}` (documents). The previous directive
  treated `grounding_context` as the general-purpose input channel, which
  disagreed with the docs and produced the broken pattern in real compiles.

  ## Evidence

  Reproduced on a fresh Mellea 0.6.0 install compiling
  `skills/weather/spec.md` (classification: A / Sequential /
  synchronous_oneshot, granite3.3:8b via ollama):

  - **Before**: every fixture (`current_conditions`, `week_forecast`,
    `rain_tomorrow`, `airport_code_query`, `temperature_query`,
    `missing_location`, `out_of_scope_historical`) returned the
    `MISSING_LOCATION_MESSAGE` decline, even when the query contained an
    explicit city.
  - **After** patching the rendered `pipeline.py` to use either
    `f"... {user_query} ..."` or `user_variables={"user_query": str(user_query)}`
    + `{{ user_query }}` in the description: `current_conditions` returns
    `Weather report: London / Sunny / 71 °F` via the `wttr_get` tool call.
    Out-of-scope and genuinely missing-location fixtures continue to take the
    correct branch.

  This PR ships the directive change so future compiles emit the corrected
  pattern; the rendered weather package will be regenerated on the next
  recompile.

  ## Files changed

  - `.claude/commands/mellea-fy-generate.md` — replaces the "MUST convert all
    non-string `grounding_context` values to `str()`" bullet with the
    refined directive; updates the canonical remediation-loop example
    (`m_fix` / `m_eval`) to use `user_variables` + Jinja.
  - `.claude/commands/mellea-fy-behaviours.md` — updates the
    `SYSTEM_PROMPT`-vs-`prefix=` example so the canonical pattern shown for
    threading a runtime value uses `user_variables` rather than
    `grounding_context`.

  ## Test plan

  - [ ] Delete `skills/weather/weather_mellea/` and `skills/weather/pyproject.toml`
  - [ ] Recompile: `mellea-skills compile skills/weather/spec.md`
  - [ ] Inspect the emitted `pipeline.py` — confirm the `m.instruct(...)` call
        uses `user_variables={"user_query": str(user_query)}` with a
        `{{ user_query }}` placeholder, NOT `grounding_context` for the
        user_query
  - [ ] `mellea-skills run skills/weather/weather_mellea --fixture current_conditions`
        → expect wttr.in weather output for London (not the missing-location
        message)
  - [ ] `--fixture out_of_scope_historical` → expect the out-of-scope decline
  - [ ] `--fixture missing_location` → expect the missing-location decline