### PR TITLE
chore(mellea-fy): bump default model to granite4.1:3b

### DIFF
--- a/.claude/commands/mellea-fy-artifacts.md
+++ b/.claude/commands/mellea-fy-artifacts.md
@@ -52,7 +52,7 @@ Numbered sections in fixed order (conditional sections omitted when not triggere
 - **§8 Generated stubs to implement** — if any `stub` or `delegate_to_runtime` dispositions: table listing every stub with its target symbol and implementation instructions
 - **§9 Fixtures and smoke test** — always present: how to run `python -m pytest fixtures/` and the expected output
 
-SETUP.md sections do NOT invent backend options. The C8 default is always `ollama` with `granite3.3:8b` unless the source spec explicitly names a different backend.
+SETUP.md sections do NOT invent backend options. The C8 default is always `ollama` with `granite4.1:3b` unless the source spec explicitly names a different backend.
 
 ---
 

--- a/.claude/commands/mellea-fy-generate.md
+++ b/.claude/commands/mellea-fy-generate.md
@@ -82,7 +82,7 @@ _JSON the model emits:_
     },
     {
       "name": "MODEL_ID",
-      "value": "granite3.3:8b",
+      "value": "granite4.1:3b",
       "type": "str",
       "category": "C8"
     },
@@ -106,7 +106,7 @@ PREFIX_TEXT: Final[str] = """You are an AI assistant.\nYou help users with resea
 
 # === C8: Runtime Environment ===
 BACKEND: Final[str] = 'ollama'
-MODEL_ID: Final[str] = 'granite3.3:8b'
+MODEL_ID: Final[str] = 'granite4.1:3b'
 
 LOOP_BUDGET: Final[int] = 3
 ```

--- a/.claude/data/runtime_defaults.json
+++ b/.claude/data/runtime_defaults.json
@@ -1,6 +1,6 @@
 {
   "format_version": "1.0",
   "backend": "ollama",
-  "model_id": "granite3.3:8b",
+  "model_id": "granite4.1:3b",
   "_comment": "Default LLM backend and model used by compiled skills at runtime. Edit this file to change the defaults for every skill you compile. To override for a single compile, run 'mellea-skills compile <spec> --backend <name> --model-id <id>'. Currently only 'ollama' is supported as the backend."
 }

--- a/.claude/schemas/runtime_defaults.schema.json
+++ b/.claude/schemas/runtime_defaults.schema.json
@@ -19,7 +19,7 @@
     "model_id": {
       "type": "string",
       "minLength": 1,
-      "description": "Model name passed to the backend (e.g. 'granite3.3:8b' for ollama). The model must be available in the user's runtime environment — the schema does not validate availability."
+      "description": "Model name passed to the backend (e.g. 'granite4.1:3b' for ollama). The model must be available in the user's runtime environment — the schema does not validate availability."
     },
     "_comment": {
       "type": "string",


### PR DESCRIPTION
- Bump the runtime default model from `granite3.3:8b` to `granite4.1:3b`.
  - Updates four files: the runtime-defaults JSON, its schema's example
    description, and two directive examples in the slash commands.
  - `_RUNTIME_DEFAULTS_FALLBACK` in `compile/claude_directives.py` is
    **intentionally NOT bumped** — it stays at `granite3.3:8b` as the
    historical last-known-good safety net for users whose
    `runtime_defaults.json` is missing or corrupt.

  ## Why

  Mellea 0.6.0 (and 0.5's PR #981 / #964) ships its own `start_session()`
  default as `granite4.1:3b` (ModelIdentifier hf=`ibm-granite/granite-4.1-3b`,
  ollama=`granite4.1:3b`) along with adapters specifically tuned for the 3B
  size. The compiler's default has been drifting behind Mellea's recommended
  adapter target since the version bump, and bumping it brings the compiler's
  emission surface back into alignment with what Mellea publishes upstream.

  ## Evidence

  Verified locally against a freshly-pulled `ollama:granite4.1:3b` on the
  existing weather skill compile (which I edited in-place to use the new
  MODEL_ID, since a clean recompile would entangle this with the in-flight
  `grounding_context → user_variables` PR):

  - `mellea-skills run skills/weather/weather_mellea --fixture london_current`
    → `london: 🌤️   +74°F` (~7s end-to-end; ~15× faster than the same fixture
    on granite3.3:8b)
  - `mellea-skills run skills/weather/weather_mellea --fixture out_of_scope_historical`
    → correctly returns the out-of-scope decline message

  ## Files changed

  - `.claude/data/runtime_defaults.json` — the single source of truth for the
    runtime default. `model_id`: `granite3.3:8b` → `granite4.1:3b`.
  - `.claude/schemas/runtime_defaults.schema.json` — the `model_id`
    description string updates the example name to match.
  - `.claude/commands/mellea-fy-generate.md` — two directive examples
    (the JSON the model emits + the rendered Python source) update their
    `MODEL_ID` value so the canonical example matches the new default.
  - `.claude/commands/mellea-fy-artifacts.md` — the SETUP.md C8-default
    prose updates the model name.

  ## Not in this PR (deliberately)

  - **`_RUNTIME_DEFAULTS_FALLBACK` in `compile/claude_directives.py`** stays at
    `granite3.3:8b`. The fallback is a disaster-recovery path for users whose
    config file is missing; bumping it in lockstep would drop those users
    onto a model they may not have pulled. When the historical default is
    eventually retired, the fallback moves in its own intentional PR.
  - **`OLLAMA_RISK_MODEL` and `OLLAMA_GUARDIAN_MODEL` in `enums.py`** are
    untouched. `OLLAMA_RISK_MODEL` is effectively dead code (only referenced
    at its definition site). `OLLAMA_GUARDIAN_MODEL` stays at
    `ibm/granite3.3-guardian:8b` will update in separate PR.

  ## Test plan

  - [ ] `ollama pull granite4.1:3b` (~1.8 GB)
  - [ ] Delete an existing compiled skill (e.g. `skills/weather/weather_mellea/`)
        and recompile: `mellea-skills compile skills/weather/spec.md`
  - [ ] Inspect the emitted `weather_mellea/config.py` —
        `MODEL_ID: Final[str] = 'granite4.1:3b'`
  - [ ] Run any fixture against the compiled skill and confirm pipeline runs
        against `model=granite4.1:3b` (visible in the
        `Starting Mellea session: backend=ollama, model=granite4.1:3b` log line)