### PR TITLE
feat(lints): add session-method-arity for MelleaSession.{instruct,chat,transform,query}

### DIFF
--- a/src/mellea_skills_compiler/compile/lints.py
+++ b/src/mellea_skills_compiler/compile/lints.py
@@ -400,6 +400,90 @@ def lint_runtime_defaults_bound(package_dir: Path) -> LintResult:
     return result
 
 
+# ─── Lint: session-method-arity ───
+#
+# Required-positional checks for MelleaSession.{instruct,chat,transform,query}.
+# Signatures pinned against Mellea 0.6.0 (verified via inspect.signature in
+# mellea.stdlib.session.MelleaSession). Revisit on Mellea version bump.
+
+_SESSION_METHOD_REQUIRED_PARAMS: dict = {
+    "instruct": ("description",),
+    "chat": ("content",),
+    "transform": ("obj", "transformation"),
+    "query": ("obj", "query"),
+}
+
+_SESSION_METHOD_LINT_SKIP_PARTS = frozenset({"__pycache__", "intermediate", "fixtures"})
+
+
+def lint_session_method_arity(package_dir: Path) -> LintResult:
+    """MelleaSession method calls must supply required positional arguments.
+
+    Catches the common emission bug where an LLM-generated pipeline calls
+    ``m.instruct(grounding_context=..., format=..., ...)`` with NO description
+    string, raising ``TypeError: MelleaSession.instruct() missing 1 required
+    positional argument: 'description'`` at runtime. Symmetric checks apply
+    to ``chat`` (``content``), ``transform`` (``obj``, ``transformation``),
+    and ``query`` (``obj``, ``query``).
+
+    Detection is method-name based: any ``<expr>.{instruct,chat,transform,
+    query}(...)`` call is checked, regardless of whether ``<expr>`` is
+    statically resolvable to a ``MelleaSession``. The false-positive risk is
+    minimal because these method names are uncommon outside the Mellea API.
+    """
+    result = LintResult(lint_id="session-method-arity", verdict="pass")
+
+    py_files: List[Path] = []
+    for p in sorted(package_dir.rglob("*.py")):
+        if any(part in _SESSION_METHOD_LINT_SKIP_PARTS for part in p.parts):
+            continue
+        py_files.append(p)
+    result.files_checked = len(py_files)
+
+    for py_file in py_files:
+        rel = py_file.relative_to(package_dir).as_posix()
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            method_name = node.func.attr
+            if method_name not in _SESSION_METHOD_REQUIRED_PARAMS:
+                continue
+
+            required = _SESSION_METHOD_REQUIRED_PARAMS[method_name]
+            n_positional = len(node.args)
+            positional_filled = set(required[:n_positional])
+            kw_filled = {kw.arg for kw in node.keywords if kw.arg is not None}
+            missing = [p for p in required if p not in positional_filled and p not in kw_filled]
+            if missing:
+                missing_str = ", ".join(f"`{m}`" for m in missing)
+                result.failures.append(
+                    LintFailure(
+                        file=rel,
+                        line=getattr(node, "lineno", None),
+                        column=getattr(node, "col_offset", None),
+                        message=(
+                            f"`.{method_name}(...)` missing required "
+                            f"argument(s): {missing_str}. Pass them "
+                            f"positionally or via keyword name. See "
+                            f"MelleaSession.{method_name} in "
+                            f"mellea.stdlib.session."
+                        ),
+                        rule_ref="session-method-arity",
+                    )
+                )
+
+    if result.failures:
+        result.verdict = "fail"
+    return result
+
+
 # ─── Runner ───
 
 
@@ -407,6 +491,7 @@ ALL_LINTS: Tuple[Callable[[Path], LintResult], ...] = (
     lint_fixtures_loader_contract,
     lint_bundled_asset_path_resolution,
     lint_runtime_defaults_bound,
+    lint_session_method_arity,
 )
 
 

--- a/tests/mellea_skills_compiler/compile/test_lints.py
+++ b/tests/mellea_skills_compiler/compile/test_lints.py
@@ -19,6 +19,7 @@ from mellea_skills_compiler.compile.lints import (
     lint_bundled_asset_path_resolution,
     lint_fixtures_loader_contract,
     lint_runtime_defaults_bound,
+    lint_session_method_arity,
     run_lints,
 )
 
@@ -558,3 +559,157 @@ class TestRunLints:
                 "run_lints should create intermediate/ when absent"
             )
             assert (pkg / "intermediate" / "step_7_report.json").exists()
+
+
+# ─── TestSessionMethodArity ───
+
+
+class TestSessionMethodArity:
+    """Test cases for lint_session_method_arity."""
+
+    def test_instruct_missing_description_fails(self):
+        """m.instruct(grounding_context=..., format=...) with no description fails.
+
+        Reproduces the ai-governance-reviewer compile failure: keyword-only
+        args supplied, required positional `description` omitted.
+        """
+        content = (
+            "def run():\n"
+            "    m.instruct(\n"
+            "        grounding_context='some text',\n"
+            "        format=SomeSchema,\n"
+            "    )\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_session_method_arity(pkg)
+            assert result.verdict == "fail", (
+                f"Expected fail for m.instruct() without description, got "
+                f"{result.verdict}: {[f.message for f in result.failures]}"
+            )
+            assert len(result.failures) == 1
+            assert "description" in result.failures[0].message
+            assert result.failures[0].file == "pipeline.py"
+
+    def test_instruct_positional_description_passes(self):
+        """m.instruct('describe the task', format=...) passes — description is positional."""
+        content = (
+            "def run():\n"
+            "    m.instruct('describe the task', format=SomeSchema)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_session_method_arity(pkg)
+            assert result.verdict == "pass", (
+                f"Expected pass for positional description, got {result.verdict}: "
+                f"{[f.message for f in result.failures]}"
+            )
+
+    def test_instruct_keyword_description_passes(self):
+        """m.instruct(description='...', format=...) passes — description as kwarg."""
+        content = (
+            "def run():\n"
+            "    m.instruct(description='task', format=SomeSchema)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_session_method_arity(pkg)
+            assert result.verdict == "pass", (
+                f"Expected pass for keyword description, got {result.verdict}: "
+                f"{[f.message for f in result.failures]}"
+            )
+
+    def test_chat_missing_content_fails(self):
+        """m.chat() with no content fails."""
+        content = "def run():\n    m.chat(format=Schema)\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_session_method_arity(pkg)
+            assert result.verdict == "fail"
+            assert "content" in result.failures[0].message
+
+    def test_transform_requires_two_positionals(self):
+        """m.transform(obj) is missing `transformation`; m.transform(obj, 'X') passes."""
+        bad = "def run():\n    m.transform(my_obj)\n"
+        good = "def run():\n    m.transform(my_obj, 'shorten the text')\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_bad = _make_package(Path(tmp) / "bad", {"pipeline.py": bad})
+            result = lint_session_method_arity(pkg_bad)
+            assert result.verdict == "fail"
+            assert "transformation" in result.failures[0].message
+            assert "obj" not in result.failures[0].message  # obj IS filled
+
+            pkg_good = _make_package(Path(tmp) / "good", {"pipeline.py": good})
+            result = lint_session_method_arity(pkg_good)
+            assert result.verdict == "pass"
+
+    def test_query_requires_obj_and_query(self):
+        """m.query() passes only when both `obj` and `query` are filled."""
+        good_kw = "def run():\n    m.query(obj=x, query='what is this?')\n"
+        bad = "def run():\n    m.query(format=S)\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_good = _make_package(Path(tmp) / "g", {"pipeline.py": good_kw})
+            assert lint_session_method_arity(pkg_good).verdict == "pass"
+            pkg_bad = _make_package(Path(tmp) / "b", {"pipeline.py": bad})
+            r = lint_session_method_arity(pkg_bad)
+            assert r.verdict == "fail"
+            assert "obj" in r.failures[0].message and "query" in r.failures[0].message
+
+    def test_non_session_method_call_skipped(self):
+        """Calls to methods of other names (e.g., .split, .append) are ignored."""
+        content = (
+            "def run():\n"
+            "    x = 'hi'.split()  # method call but not a session method\n"
+            "    lst.append(1)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_session_method_arity(pkg)
+            assert result.verdict == "pass"
+            assert result.failures == []
+
+    def test_skips_pycache_intermediate_fixtures(self):
+        """Files under __pycache__, intermediate/, and fixtures/ are not checked."""
+        bad_call = "def x():\n    m.instruct(format=S)\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "intermediate/_old.py": bad_call,  # should be skipped
+                    "fixtures/some_fixture.py": bad_call,  # should be skipped
+                    "__pycache__/cached.py": bad_call,  # should be skipped
+                    "pipeline.py": "def y():\n    m.instruct('valid', format=S)\n",
+                },
+            )
+            result = lint_session_method_arity(pkg)
+            assert result.verdict == "pass", (
+                f"Skipped paths should not produce failures; got "
+                f"{[f.file for f in result.failures]}"
+            )
+
+    def test_both_calls_in_one_file_report_both(self):
+        """Two broken m.instruct() calls in the same file should produce two failures."""
+        content = (
+            "def f():\n"
+            "    m.instruct(grounding_context='a', format=S)\n"
+            "    m.instruct(grounding_context='b', format=S)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_session_method_arity(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 2, (
+                f"Expected 2 failures, got {len(result.failures)}: "
+                f"{[f.message for f in result.failures]}"
+            )
+
+    def test_syntax_error_file_is_skipped_silently(self):
+        """A file that fails to parse is skipped, not raised."""
+        content = "def broken(:\n    pass\n"  # syntax error
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_session_method_arity(pkg)
+            # Either pass (no detectable failure) or skip — but no exception
+            assert result.verdict in ("pass", "skipped"), (
+                f"Syntax-error file should not raise; got verdict={result.verdict}"
+            )


### PR DESCRIPTION
 ## Summary
  
  - New Step 7 lint `session-method-arity` that catches `m.instruct(...)`,
    `m.chat(...)`, `m.transform(...)`, `m.query(...)` calls missing required
    positional arguments (`description`, `content`, `obj`/`transformation`,
    `obj`/`query` respectively).
  - Hardcoded signature table pinned against Mellea 0.6.0 (verified via
    `inspect.signature` on `mellea.stdlib.session.MelleaSession` — comment in
    the lint flags it for revisit on Mellea version bumps).
  - Pure-AST detection; no surface dependency, no runtime side effects.
  
  ## Why
  
  A skill compile (ai-governance-reviewer-carl-ditzler) passed in-session
  Step 7 with verdict `pass`, passed the three wrapper-side lints, then failed
  at smoke check with `TypeError: MelleaSession.instruct() missing 1 required
  positional argument: 'description'`. Both `m.instruct(...)` calls in the
  emitted `pipeline.py` had supplied `grounding_context=`, `format=`,
  `strategy=`, and `model_options=` as keyword arguments but omitted the
  required `description` positional — silently structurally illegal Python
  that no current lint catches.

  This is a recurring class: LLM-generated pipelines sometimes call session
  methods with keyword-only args and omit the required positional. The bug
  is detectable from the AST alone — no runtime execution needed.

  The fork's `lint_stdlib_arity` (referenced in `mellea-fy-validate.md`)
  explicitly excludes method calls because of the `self` arg complication;
  see fork `lints.py:2497-2508` docstring. This new lint covers the
  method-call case the fork's lint walks away from.

  ## How

  `lint_session_method_arity` walks every `*.py` under `<package>/` (skipping
  `__pycache__/`, `intermediate/`, `fixtures/`). For each `ast.Call` whose
  callee is an `ast.Attribute` with `.attr` in
  `{instruct, chat, transform, query}`, it computes which required
  parameters are filled (positional or keyword) against the pinned signature
  table and emits a `LintFailure` for each missing one.

  Detection is method-name-based rather than receiver-type-based — i.e.,
  the lint doesn't try to prove the receiver is statically a
  `MelleaSession`. The false-positive risk is minimal because these method
  names are uncommon outside the Mellea API; the unit test
  `test_non_session_method_call_skipped` exercises common collisions
  (`.split()`, `.append()`) and confirms they're ignored.
  
  Signatures captured (Mellea 0.6.0, `inspect.signature` on
  `MelleaSession`):
  
  | Method | Required positional(s) |
  |---|---|
  | `instruct` | `description` |
  | `chat` | `content` |
  | `transform` | `obj`, `transformation` |
  | `query` | `obj`, `query` |

  ## Evidence
  
  Run against the actual ai-governance-reviewer compile that produced the
  runtime TypeError:

  verdict: fail
  files_checked: 10
  failures (2):
    pipeline.py:285:27  .instruct(...) missing required argument(s): description. ...
    pipeline.py:350:23  .instruct(...) missing required argument(s): description. ...

  Run against a known-good weather compile (description correctly supplied
  via Jinja in `user_variables`):
  
  verdict: pass
  files_checked: 9
  failures: 0
  
  ## Files changed
  
  - `src/mellea_skills_compiler/compile/lints.py` — new lint function +
    added to `ALL_LINTS`. +85 lines.
  - `tests/mellea_skills_compiler/compile/test_lints.py` — new
    `TestSessionMethodArity` class with 10 cases covering: missing
    description, positional description pass, keyword description pass,
    missing content for chat, transform two-positional requirement, query
    obj+query requirement, non-session-method skip, path-skip
    (__pycache__/intermediate/fixtures), multiple failures in one file,
    syntax-error file is skipped not raised. +155 lines.

  ## Test plan
  
  - [ ] `pytest tests/mellea_skills_compiler/compile/test_lints.py` — should
        show 39 passed (29 existing + 10 new)
  - [ ] `pytest tests/` — full suite should still pass
  - [ ] Optional: compile any skill with `mellea-skills compile <spec>` and
        check `intermediate/step_7_report.json` now includes a fourth lint
        entry `session-method-arity` alongside the existing three