### PR TITLE
fix(smoke): classify ModuleNotFoundError on declared deps as skipped, not failed

### DIFF
--- a/src/mellea_skills_compiler/compile/smoke_check.py
+++ b/src/mellea_skills_compiler/compile/smoke_check.py
@@ -17,6 +17,7 @@ fixture failures require human review per `mellea-fy-validate.md`.
 from __future__ import annotations
 
 import json
+import re
 import time
 import traceback
 from dataclasses import asdict, dataclass, field
@@ -32,6 +33,78 @@ from mellea_skills_compiler.toolkit.logging import configure_logger
 
 
 LOGGER = configure_logger()
+
+
+# Known mismatches between Python import names and PyPI package names.
+# Extend as new mismatches are observed in compiled skills. The minimum entry
+# point is one direction: import-name -> PyPI-name; the lookup is applied
+# during _is_declared_dependency only when a direct/normalised match fails.
+_IMPORT_TO_PYPI: Dict[str, str] = {
+    "docx": "python-docx",
+    "yaml": "pyyaml",
+    "cv2": "opencv-python",
+    "PIL": "pillow",
+    "sklearn": "scikit-learn",
+    "bs4": "beautifulsoup4",
+    "magic": "python-magic",
+    "dotenv": "python-dotenv",
+    "Crypto": "pycryptodome",
+}
+
+
+def _declared_dependency_names(skill_dir: Path) -> Optional[set]:
+    """Return the set of canonical dep names from skill_dir/pyproject.toml.
+
+    Returns ``None`` if pyproject.toml is missing or unreadable — the caller
+    treats that as 'cannot determine declared deps' and falls through to the
+    failed-classification path.
+    """
+    pyproject = skill_dir / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:  # pragma: no cover — project requires 3.11+
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except Exception:  # noqa: BLE001 — malformed TOML treated as 'unknown'
+        return None
+    deps = data.get("project", {}).get("dependencies", []) or []
+    names: set = set()
+    for dep in deps:
+        if not isinstance(dep, str):
+            continue
+        # PEP 508 head extraction: name [extras] [version-spec] [; markers]
+        head = re.split(r"[\s<>=!~\[;]", dep, maxsplit=1)[0].strip().lower()
+        if head:
+            names.add(head)
+            names.add(head.replace("-", "_"))
+            names.add(head.replace("_", "-"))
+    return names
+
+
+def _is_declared_dependency(missing_module: str, skill_dir: Path) -> bool:
+    """True if ``missing_module`` corresponds to a dep in skill_dir/pyproject.toml.
+
+    Matching strategy: lowercase + hyphen/underscore normalisation, then a
+    small hardcoded import-name -> PyPI-name table for known mismatches
+    (e.g. ``docx`` -> ``python-docx``, ``yaml`` -> ``pyyaml``).
+    """
+    declared = _declared_dependency_names(skill_dir)
+    if not declared:
+        return False
+    name = missing_module.lower()
+    candidates = {name, name.replace("_", "-"), name.replace("-", "_")}
+    mapped = _IMPORT_TO_PYPI.get(missing_module) or _IMPORT_TO_PYPI.get(name)
+    if mapped:
+        mapped_lower = mapped.lower()
+        candidates |= {
+            mapped_lower,
+            mapped_lower.replace("-", "_"),
+            mapped_lower.replace("_", "-"),
+        }
+    return bool(declared & candidates)
 
 
 @dataclass
@@ -58,15 +131,38 @@ class SmokeRunResult:
         return 0
 
 
-def _classify_exception(exc: BaseException) -> Optional[str]:
-    """Return a non-None 'skipped' reason if the exception indicates backend unreachable.
+def _classify_exception(
+    exc: BaseException, skill_dir: Optional[Path] = None
+) -> Optional[str]:
+    """Return a non-None 'skipped' reason if the exception is environmental.
 
-    Detection covers the common forms: stdlib socket/connection errors, httpx/
-    requests library variants (by class name to avoid hard imports), HTTP
-    auth failures, and timeouts.
+    Two classes of skip:
+
+    1. Backend unreachable — stdlib socket/connection errors, httpx/requests
+       library variants (by class name to avoid hard imports), HTTP auth
+       failures, and timeouts.
+    2. Declared dependency missing from the compile-process venv — a
+       ``ModuleNotFoundError`` whose missing module corresponds to a dep
+       declared in ``skill_dir/pyproject.toml``. The skill compiles fine;
+       the user just needs ``pip install -e .`` before runtime verification.
+       Distinguished from a real code bug (LLM imports something it didn't
+       declare), which is left to fall through to the failed path.
     """
     cls_name = type(exc).__name__
     cls_module = type(exc).__module__
+
+    # Declared-dependency-missing — environmental, not a code bug.
+    # Checked first so a ModuleNotFoundError that LOOKS network-like (e.g.
+    # ConnectionError from a missing urllib3) doesn't get misclassified.
+    if isinstance(exc, ModuleNotFoundError) and skill_dir is not None:
+        missing = (getattr(exc, "name", None) or "").split(".")[0]
+        if missing and _is_declared_dependency(missing, skill_dir):
+            return (
+                f"declared dependency {missing!r} not installed in the "
+                f"compile-process venv. The skill's pyproject.toml declares "
+                f"it; run `pip install -e .` in the skill directory and "
+                f"re-run the smoke check to verify runtime behaviour."
+            )
 
     # stdlib network errors
     if isinstance(exc, (ConnectionError, ConnectionRefusedError, ConnectionAbortedError, ConnectionResetError)):
@@ -88,7 +184,11 @@ def _classify_exception(exc: BaseException) -> Optional[str]:
     return None
 
 
-def _run_one_fixture(pipeline_fn, fixture: Dict[str, Any]) -> SmokeFixtureResult:
+def _run_one_fixture(
+    pipeline_fn,
+    fixture: Dict[str, Any],
+    skill_dir: Optional[Path] = None,
+) -> SmokeFixtureResult:
     fixture_id = fixture.get("id", "<unknown>")
     started = time.time()
     try:
@@ -99,7 +199,7 @@ def _run_one_fixture(pipeline_fn, fixture: Dict[str, Any]) -> SmokeFixtureResult
             pipeline_fn(context)
     except BaseException as exc:  # noqa: BLE001 — we re-classify all
         duration = time.time() - started
-        skipped_reason = _classify_exception(exc)
+        skipped_reason = _classify_exception(exc, skill_dir=skill_dir)
         if skipped_reason:
             LOGGER.warning(
                 "Fixture smoke-check skipped — %s. Re-run `mellea-skills validate <pkg> --run` "
@@ -139,9 +239,16 @@ def run_smoke_check(package_dir: Path, all_fixtures: bool = False) -> SmokeRunRe
 
     targets = fixtures if all_fixtures else fixtures[:1]
 
+    # The skill root sits one level above the compiled package; pyproject.toml
+    # lives at the skill root (Rule OUT-3). Pass it through so ModuleNotFoundError
+    # classification can distinguish declared-dep-missing from real-bug.
+    skill_dir = package_dir.parent
+
     fixture_results: List[SmokeFixtureResult] = []
     for fixture in targets:
-        fixture_results.append(_run_one_fixture(pipeline_fn, fixture))
+        fixture_results.append(
+            _run_one_fixture(pipeline_fn, fixture, skill_dir=skill_dir)
+        )
 
     if any(r.verdict == "failed" for r in fixture_results):
         overall = "failed"

--- a/tests/mellea_skills_compiler/compile/test_smoke_check.py
+++ b/tests/mellea_skills_compiler/compile/test_smoke_check.py
@@ -2,11 +2,13 @@
 
 import json
 import time
+from pathlib import Path
 
 import pytest
 
 from mellea_skills_compiler.compile.smoke_check import (
     _classify_exception,
+    _is_declared_dependency,
     _run_one_fixture,
     run_smoke_check,
 )
@@ -239,3 +241,124 @@ class TestRunSmokeCheck:
 
         result = run_smoke_check(tmp_path, all_fixtures=False)
         assert result.exit_code == 0
+
+
+# ─── TestDeclaredDependencyClassification ───
+
+
+def _make_skill_dir(tmp_path, deps: list) -> Path:
+    """Materialise a minimal skill dir with a pyproject.toml declaring `deps`."""
+    skill = tmp_path / "test_skill"
+    skill.mkdir()
+    deps_block = ",\n    ".join(f'"{d}"' for d in deps)
+    pyproject = f"""[build-system]
+requires = ["setuptools>=68.0"]
+
+[project]
+name = "test-skill"
+version = "0.1.0"
+dependencies = [
+    {deps_block}
+]
+"""
+    (skill / "pyproject.toml").write_text(pyproject)
+    return skill
+
+
+class TestIsDeclaredDependency:
+    """Test cases for _is_declared_dependency()."""
+
+    def test_direct_name_match(self, tmp_path):
+        skill = _make_skill_dir(tmp_path, ["pydantic>=2.0"])
+        assert _is_declared_dependency("pydantic", skill) is True
+
+    def test_known_import_to_pypi_mapping_docx(self, tmp_path):
+        """`docx` (import) maps to `python-docx` (PyPI) — the matter-intake case."""
+        skill = _make_skill_dir(tmp_path, ["python-docx>=1.1"])
+        assert _is_declared_dependency("docx", skill) is True
+
+    def test_known_import_to_pypi_mapping_yaml(self, tmp_path):
+        skill = _make_skill_dir(tmp_path, ["pyyaml>=6"])
+        assert _is_declared_dependency("yaml", skill) is True
+
+    def test_known_import_to_pypi_mapping_sklearn(self, tmp_path):
+        skill = _make_skill_dir(tmp_path, ["scikit-learn>=1.0"])
+        assert _is_declared_dependency("sklearn", skill) is True
+
+    def test_underscore_hyphen_normalisation(self, tmp_path):
+        skill = _make_skill_dir(tmp_path, ["python_dotenv>=1.0"])
+        assert _is_declared_dependency("dotenv", skill) is True
+
+    def test_undeclared_returns_false(self, tmp_path):
+        skill = _make_skill_dir(tmp_path, ["pydantic>=2.0"])
+        assert _is_declared_dependency("nonexistent_package", skill) is False
+
+    def test_missing_pyproject_returns_false(self, tmp_path):
+        skill = tmp_path / "no_pyproject"
+        skill.mkdir()
+        assert _is_declared_dependency("docx", skill) is False
+
+    def test_malformed_pyproject_returns_false(self, tmp_path):
+        skill = tmp_path / "bad_pyproject"
+        skill.mkdir()
+        (skill / "pyproject.toml").write_text("not valid [[[ toml")
+        assert _is_declared_dependency("docx", skill) is False
+
+    def test_empty_dependencies_returns_false(self, tmp_path):
+        skill = tmp_path / "empty_deps"
+        skill.mkdir()
+        (skill / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+        )
+        assert _is_declared_dependency("docx", skill) is False
+
+
+class TestClassifyExceptionWithSkillDir:
+    """ModuleNotFoundError classification with the new skill_dir signature."""
+
+    def test_modulenotfound_declared_classified_as_skipped(self, tmp_path):
+        """The matter-intake case: docx missing but declared as python-docx."""
+        skill = _make_skill_dir(tmp_path, ["python-docx>=1.1", "pydantic>=2.0"])
+        exc = ModuleNotFoundError("No module named 'docx'")
+        exc.name = "docx"  # ModuleNotFoundError carries the missing name
+        reason = _classify_exception(exc, skill_dir=skill)
+        assert reason is not None
+        assert "docx" in reason
+        assert "pip install -e ." in reason
+
+    def test_modulenotfound_undeclared_falls_through(self, tmp_path):
+        """If the LLM imports something it didn't declare, that's a real bug."""
+        skill = _make_skill_dir(tmp_path, ["pydantic>=2.0"])
+        exc = ModuleNotFoundError("No module named 'sneaky_undeclared'")
+        exc.name = "sneaky_undeclared"
+        reason = _classify_exception(exc, skill_dir=skill)
+        assert reason is None  # falls through to failed-classification path
+
+    def test_modulenotfound_without_skill_dir_falls_through(self):
+        """When the classifier has no skill_dir context, fall through to failed."""
+        exc = ModuleNotFoundError("No module named 'docx'")
+        exc.name = "docx"
+        reason = _classify_exception(exc, skill_dir=None)
+        assert reason is None
+
+    def test_modulenotfound_with_submodule(self, tmp_path):
+        """`No module named 'docx.shared'` should match the top-level `docx`."""
+        skill = _make_skill_dir(tmp_path, ["python-docx>=1.1"])
+        exc = ModuleNotFoundError("No module named 'docx.shared'")
+        exc.name = "docx.shared"
+        reason = _classify_exception(exc, skill_dir=skill)
+        assert reason is not None
+        assert "docx" in reason
+
+    def test_existing_connection_error_classification_preserved(self, tmp_path):
+        """The new code path must not regress backend-unreachable detection."""
+        skill = _make_skill_dir(tmp_path, ["pydantic>=2.0"])
+        reason = _classify_exception(ConnectionError("nope"), skill_dir=skill)
+        assert reason is not None
+        assert reason.startswith("backend unreachable: ConnectionError")
+
+    def test_existing_signature_still_works(self):
+        """_classify_exception(exc) without skill_dir kwarg still works (legacy)."""
+        reason = _classify_exception(ConnectionError("nope"))
+        assert reason is not None
+        assert reason.startswith("backend unreachable: ConnectionError")


### PR DESCRIPTION
## Summary

- Refine `_classify_exception` in `compile/smoke_check.py` so a
  `ModuleNotFoundError` is classified as `skipped` (environmental) when
  the missing module corresponds to a dependency declared in the
  skill's `pyproject.toml`. When the missing module is NOT declared, the
  exception still falls through to `failed` (a real code bug).
- Thread `skill_dir` through `_run_one_fixture` and `_classify_exception`
  so the classifier can read `pyproject.toml`.
- Add a small import-name → PyPI-name mapping (`_IMPORT_TO_PYPI`) for
  the known mismatches an LLM-generated skill is likely to hit (`docx`
  → `python-docx`, `yaml` → `pyyaml`, `cv2` → `opencv-python`, `PIL` →
  `pillow`, `sklearn` → `scikit-learn`, `bs4` → `beautifulsoup4`,
  `magic` → `python-magic`, `dotenv` → `python-dotenv`, `Crypto` →
  `pycryptodome`).

## Why

A compile of `lawveai-skills/matter-intake-scoping-scott-margetts`
produced a clean, lint-passing package that the smoke check then
classified as `failed` with
`ModuleNotFoundError: No module named 'docx'`. The skill correctly
declared `python-docx>=1.1` in its `pyproject.toml`, correctly recorded
the dep in `dependencies.yaml`, and lazily imported `docx` inside the
tool function — nothing about the emitted code was wrong. The failure
was that the compile-process venv (`.venv`) didn't have `python-docx`
installed, because the compile process never `pip install -e .`s the
package it just generated.

Today's `_classify_exception` only recognises *backend-unreachable*
patterns (connection errors, timeouts, 401/403). `ModuleNotFoundError`
falls through to `failed` (exit code 12), conflating two genuinely
different situations:

| Situation | Today | Should be |
|---|---|---|
| Compile env missing a **declared** dep | `failed` | `skipped` (run `pip install -e .`) |
| Compile env missing an **undeclared** dep (LLM imported something it didn't declare) | `failed` | `failed` (real code bug) |

This PR distinguishes them via `pyproject.toml` lookup, symmetric with
how backend-unreachable is already handled.

## Empirical evidence

Reproduced against the actual matter-intake compile that motivated this
fix:

```
skill_dir: lawveai-skills/matter-intake-scoping-scott-margetts
pyproject exists: True

_is_declared_dependency('docx', skill_dir): True

_classify_exception(exc, skill_dir=skill_dir):
  verdict: skipped
  reason:  declared dependency 'docx' not installed in the compile-process
           venv. The skill's pyproject.toml declares it; run
           `pip install -e .` in the skill directory and re-run the
           smoke check to verify runtime behaviour.

Negative test (undeclared module 'sneaky_unbundled_thing'):
  verdict: failed (real bug)
```

The matter-intake case correctly classifies as `skipped` with an
actionable next-step message; an undeclared-module case correctly
falls through to `failed` and surfaces the real bug.

## How

`_classify_exception` now accepts an optional `skill_dir` and checks
`ModuleNotFoundError` first. When `skill_dir` is provided and the
missing module corresponds to a declared dep, it returns a
`skipped`-style reason. Match strategy: lowercase + hyphen/underscore
normalisation against names extracted from `[project] dependencies`
(PEP 508 head-of-spec), then a hardcoded import-name → PyPI-name table
for known mismatches.

`run_smoke_check` derives `skill_dir = package_dir.parent` (Rule OUT-3:
`pyproject.toml` lives at the skill root, one above the compiled
package) and threads it through `_run_one_fixture` →
`_classify_exception`.

`_classify_exception(exc)` (legacy single-arg signature) still works
when called without `skill_dir` — the ModuleNotFoundError branch
simply returns None (falls through to failed) when no skill_dir
context is provided, preserving existing behaviour.

## Files changed

- `src/mellea_skills_compiler/compile/smoke_check.py` — new helpers
  `_declared_dependency_names`, `_is_declared_dependency`, the
  `_IMPORT_TO_PYPI` mapping table; `_classify_exception` gains optional
  `skill_dir`; `_run_one_fixture` gains optional `skill_dir`;
  `run_smoke_check` derives `skill_dir` and passes it through.
- `tests/mellea_skills_compiler/compile/test_smoke_check.py` — two new
  test classes: `TestIsDeclaredDependency` (9 cases covering direct
  match, PyPI-name mapping for docx/yaml/sklearn, underscore-hyphen
  normalisation, undeclared module, missing pyproject, malformed
  pyproject, empty dependencies) and `TestClassifyExceptionWithSkillDir`
  (6 cases covering declared-skipped, undeclared-fallthrough, no-skill-dir
  fallthrough, submodule handling, regression preservation, legacy
  signature compatibility).

## Test plan

- [ ] `pytest tests/mellea_skills_compiler/compile/test_smoke_check.py`
      → 36 passed (21 existing + 15 new)
- [ ] `pytest tests/` → 164 passed, no regressions
- [ ] Manual: with the matter-intake compile still on disk, uninstall
      `python-docx` from `.venv` and re-run the smoke. With this fix,
      expect `skipped` verdict + actionable message; without it,
      `failed`.