### PR TITLE
feat(lints): add validation-fn-not-called-directly to catch Requirement misuse

### DIFF
--- a/src/mellea_skills_compiler/compile/lints.py
+++ b/src/mellea_skills_compiler/compile/lints.py
@@ -417,20 +417,7 @@ _SESSION_METHOD_LINT_SKIP_PARTS = frozenset({"__pycache__", "intermediate", "fix
 
 
 def lint_session_method_arity(package_dir: Path) -> LintResult:
-    """MelleaSession method calls must supply required positional arguments.
-
-    Catches the common emission bug where an LLM-generated pipeline calls
-    ``m.instruct(grounding_context=..., format=..., ...)`` with NO description
-    string, raising ``TypeError: MelleaSession.instruct() missing 1 required
-    positional argument: 'description'`` at runtime. Symmetric checks apply
-    to ``chat`` (``content``), ``transform`` (``obj``, ``transformation``),
-    and ``query`` (``obj``, ``query``).
-
-    Detection is method-name based: any ``<expr>.{instruct,chat,transform,
-    query}(...)`` call is checked, regardless of whether ``<expr>`` is
-    statically resolvable to a ``MelleaSession``. The false-positive risk is
-    minimal because these method names are uncommon outside the Mellea API.
-    """
+    """MelleaSession method calls must supply required positional arguments."""
     result = LintResult(lint_id="session-method-arity", verdict="pass")
 
     py_files: List[Path] = []
@@ -484,6 +471,76 @@ def lint_session_method_arity(package_dir: Path) -> LintResult:
     return result
 
 
+# ─── Lint: validation-fn-not-called-directly ───
+#
+# Mellea's ``Requirement.validation_fn`` is internal sampling-loop plumbing.
+# User-emitted code should never call ``<req>.validation_fn(...)`` directly:
+# doing so triggers ``AttributeError: 'dict' object has no attribute
+# 'last_output'`` at the ``simple_validate(...)`` wrapper. Use
+# ``req.validate(backend, ctx, ...)`` for output validation, or plain Python
+# ``if/raise ValueError(...)`` for input preconditions.
+
+_VALIDATION_FN_LINT_SKIP_PARTS = frozenset(
+    {"__pycache__", "intermediate", "fixtures"}
+)
+
+
+def lint_validation_fn_not_called_directly(package_dir: Path) -> LintResult:
+    """Reject any direct call to ``<req>.validation_fn(...)`` in generated code."""
+    result = LintResult(lint_id="validation-fn-not-called-directly", verdict="pass")
+
+    py_files: List[Path] = []
+    for p in sorted(package_dir.rglob("*.py")):
+        if any(part in _VALIDATION_FN_LINT_SKIP_PARTS for part in p.parts):
+            continue
+        py_files.append(p)
+    result.files_checked = len(py_files)
+
+    for py_file in py_files:
+        rel = py_file.relative_to(package_dir).as_posix()
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "validation_fn":
+                continue
+            try:
+                rendered = ast.unparse(node)
+            except Exception:  # pragma: no cover — defensive
+                rendered = "<call>"
+            result.failures.append(
+                LintFailure(
+                    file=rel,
+                    line=getattr(node, "lineno", None),
+                    column=getattr(node, "col_offset", None),
+                    message=(
+                        f"`{rendered}` — direct call to `.validation_fn` is "
+                        f"not the public Mellea API. `Requirement.validation_fn` "
+                        f"is internal sampling-loop plumbing; invoking it "
+                        f"directly typically raises AttributeError at runtime "
+                        f"(the `simple_validate(...)` wrapper calls "
+                        f"`ctx.last_output()` on its argument). For "
+                        f"output validation use `req.validate(backend, ctx, ...)` "
+                        f"or attach the Requirement to a sampling strategy. "
+                        f"For input-argument preconditions use plain Python "
+                        f"`if/raise ValueError(...)` — Requirement is for "
+                        f"model-output validation, not input precondition checks."
+                    ),
+                    rule_ref="validation-fn-not-called-directly",
+                )
+            )
+
+    if result.failures:
+        result.verdict = "fail"
+    return result
+
+
 # ─── Runner ───
 
 
@@ -492,6 +549,7 @@ ALL_LINTS: Tuple[Callable[[Path], LintResult], ...] = (
     lint_bundled_asset_path_resolution,
     lint_runtime_defaults_bound,
     lint_session_method_arity,
+    lint_validation_fn_not_called_directly,
 )
 
 

--- a/tests/mellea_skills_compiler/compile/test_lints.py
+++ b/tests/mellea_skills_compiler/compile/test_lints.py
@@ -20,6 +20,7 @@ from mellea_skills_compiler.compile.lints import (
     lint_fixtures_loader_contract,
     lint_runtime_defaults_bound,
     lint_session_method_arity,
+    lint_validation_fn_not_called_directly,
     run_lints,
 )
 
@@ -568,11 +569,7 @@ class TestSessionMethodArity:
     """Test cases for lint_session_method_arity."""
 
     def test_instruct_missing_description_fails(self):
-        """m.instruct(grounding_context=..., format=...) with no description fails.
-
-        Reproduces the ai-governance-reviewer compile failure: keyword-only
-        args supplied, required positional `description` omitted.
-        """
+        """m.instruct(grounding_context=..., format=...) with no description fails."""
         content = (
             "def run():\n"
             "    m.instruct(\n"
@@ -592,35 +589,24 @@ class TestSessionMethodArity:
             assert result.failures[0].file == "pipeline.py"
 
     def test_instruct_positional_description_passes(self):
-        """m.instruct('describe the task', format=...) passes — description is positional."""
         content = (
             "def run():\n"
             "    m.instruct('describe the task', format=SomeSchema)\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"pipeline.py": content})
-            result = lint_session_method_arity(pkg)
-            assert result.verdict == "pass", (
-                f"Expected pass for positional description, got {result.verdict}: "
-                f"{[f.message for f in result.failures]}"
-            )
+            assert lint_session_method_arity(pkg).verdict == "pass"
 
     def test_instruct_keyword_description_passes(self):
-        """m.instruct(description='...', format=...) passes — description as kwarg."""
         content = (
             "def run():\n"
             "    m.instruct(description='task', format=SomeSchema)\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"pipeline.py": content})
-            result = lint_session_method_arity(pkg)
-            assert result.verdict == "pass", (
-                f"Expected pass for keyword description, got {result.verdict}: "
-                f"{[f.message for f in result.failures]}"
-            )
+            assert lint_session_method_arity(pkg).verdict == "pass"
 
     def test_chat_missing_content_fails(self):
-        """m.chat() with no content fails."""
         content = "def run():\n    m.chat(format=Schema)\n"
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"pipeline.py": content})
@@ -629,7 +615,6 @@ class TestSessionMethodArity:
             assert "content" in result.failures[0].message
 
     def test_transform_requires_two_positionals(self):
-        """m.transform(obj) is missing `transformation`; m.transform(obj, 'X') passes."""
         bad = "def run():\n    m.transform(my_obj)\n"
         good = "def run():\n    m.transform(my_obj, 'shorten the text')\n"
         with tempfile.TemporaryDirectory() as tmp:
@@ -637,14 +622,12 @@ class TestSessionMethodArity:
             result = lint_session_method_arity(pkg_bad)
             assert result.verdict == "fail"
             assert "transformation" in result.failures[0].message
-            assert "obj" not in result.failures[0].message  # obj IS filled
+            assert "obj" not in result.failures[0].message
 
             pkg_good = _make_package(Path(tmp) / "good", {"pipeline.py": good})
-            result = lint_session_method_arity(pkg_good)
-            assert result.verdict == "pass"
+            assert lint_session_method_arity(pkg_good).verdict == "pass"
 
     def test_query_requires_obj_and_query(self):
-        """m.query() passes only when both `obj` and `query` are filled."""
         good_kw = "def run():\n    m.query(obj=x, query='what is this?')\n"
         bad = "def run():\n    m.query(format=S)\n"
         with tempfile.TemporaryDirectory() as tmp:
@@ -656,10 +639,9 @@ class TestSessionMethodArity:
             assert "obj" in r.failures[0].message and "query" in r.failures[0].message
 
     def test_non_session_method_call_skipped(self):
-        """Calls to methods of other names (e.g., .split, .append) are ignored."""
         content = (
             "def run():\n"
-            "    x = 'hi'.split()  # method call but not a session method\n"
+            "    x = 'hi'.split()\n"
             "    lst.append(1)\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
@@ -669,26 +651,21 @@ class TestSessionMethodArity:
             assert result.failures == []
 
     def test_skips_pycache_intermediate_fixtures(self):
-        """Files under __pycache__, intermediate/, and fixtures/ are not checked."""
         bad_call = "def x():\n    m.instruct(format=S)\n"
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(
                 Path(tmp),
                 {
-                    "intermediate/_old.py": bad_call,  # should be skipped
-                    "fixtures/some_fixture.py": bad_call,  # should be skipped
-                    "__pycache__/cached.py": bad_call,  # should be skipped
+                    "intermediate/_old.py": bad_call,
+                    "fixtures/some_fixture.py": bad_call,
+                    "__pycache__/cached.py": bad_call,
                     "pipeline.py": "def y():\n    m.instruct('valid', format=S)\n",
                 },
             )
             result = lint_session_method_arity(pkg)
-            assert result.verdict == "pass", (
-                f"Skipped paths should not produce failures; got "
-                f"{[f.file for f in result.failures]}"
-            )
+            assert result.verdict == "pass"
 
     def test_both_calls_in_one_file_report_both(self):
-        """Two broken m.instruct() calls in the same file should produce two failures."""
         content = (
             "def f():\n"
             "    m.instruct(grounding_context='a', format=S)\n"
@@ -698,18 +675,114 @@ class TestSessionMethodArity:
             pkg = _make_package(Path(tmp), {"pipeline.py": content})
             result = lint_session_method_arity(pkg)
             assert result.verdict == "fail"
-            assert len(result.failures) == 2, (
-                f"Expected 2 failures, got {len(result.failures)}: "
-                f"{[f.message for f in result.failures]}"
-            )
+            assert len(result.failures) == 2
 
     def test_syntax_error_file_is_skipped_silently(self):
-        """A file that fails to parse is skipped, not raised."""
-        content = "def broken(:\n    pass\n"  # syntax error
+        content = "def broken(:\n    pass\n"
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"pipeline.py": content})
             result = lint_session_method_arity(pkg)
-            # Either pass (no detectable failure) or skip — but no exception
-            assert result.verdict in ("pass", "skipped"), (
-                f"Syntax-error file should not raise; got verdict={result.verdict}"
+            assert result.verdict in ("pass", "skipped")
+
+
+# ─── TestValidationFnNotCalledDirectly ───
+
+
+class TestValidationFnNotCalledDirectly:
+    """Test cases for lint_validation_fn_not_called_directly."""
+
+    def test_direct_call_on_req_attribute_fails(self):
+        content = (
+            "def check():\n"
+            "    result = req.validation_fn(ctx)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_validation_fn_not_called_directly(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 1
+            assert "validation_fn" in result.failures[0].message
+
+    def test_attribute_access_no_call_passes(self):
+        content = (
+            "def check():\n"
+            "    if req.validation_fn is not None:\n"
+            "        pass\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            assert lint_validation_fn_not_called_directly(pkg).verdict == "pass"
+
+    def test_bare_name_call_passes(self):
+        content = (
+            "def check():\n"
+            "    validation_fn = lambda s: True\n"
+            "    validation_fn('hi')\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            assert lint_validation_fn_not_called_directly(pkg).verdict == "pass"
+
+    def test_req_validate_passes(self):
+        content = (
+            "async def check():\n"
+            "    result = await req.validate(backend, ctx)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            assert lint_validation_fn_not_called_directly(pkg).verdict == "pass"
+
+    def test_other_method_calls_not_flagged(self):
+        content = (
+            "def check():\n"
+            "    x.some_other_method('a')\n"
+            "    y.append(1)\n"
+            "    z.run(ctx)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            assert lint_validation_fn_not_called_directly(pkg).verdict == "pass"
+
+    def test_multiple_failures_in_one_file_all_reported(self):
+        content = (
+            "def check():\n"
+            "    r1 = req_a.validation_fn(arg_a)\n"
+            "    r2 = req_b.validation_fn(arg_b)\n"
+            "    r3 = some.req_c.validation_fn(arg_c)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_validation_fn_not_called_directly(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 3
+
+    def test_skips_pycache_intermediate_fixtures(self):
+        bad = "def x():\n    req.validation_fn(arg)\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "intermediate/_x.py": bad,
+                    "fixtures/some.py": bad,
+                    "__pycache__/cached.py": bad,
+                    "pipeline.py": "def y():\n    pass\n",
+                },
             )
+            assert lint_validation_fn_not_called_directly(pkg).verdict == "pass"
+
+    def test_syntax_error_file_silently_skipped(self):
+        content = "def broken(:\n    pass\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_validation_fn_not_called_directly(pkg)
+            assert result.verdict in ("pass", "skipped")
+
+    def test_failure_message_guides_to_correct_idiom(self):
+        content = "def x():\n    req.validation_fn(ctx)\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": content})
+            result = lint_validation_fn_not_called_directly(pkg)
+            assert result.verdict == "fail"
+            msg = result.failures[0].message
+            assert "req.validate" in msg
+            assert "ValueError" in msg


### PR DESCRIPTION

  ## Summary

  - New Step 7 lint `validation-fn-not-called-directly` that flags every
    `<expr>.validation_fn(...)` call in generated package code.
  - `Requirement.validation_fn` is internal Mellea sampling-loop plumbing
    with shape `Callable[[Context], ValidationResult]`. Direct invocation
    from user code is structurally wrong — the public API is
    `req.validate(backend, ctx, ...)` (or letting a sampling strategy
    invoke it).
  - Pure-AST detection, no surface dependency, near-zero false-positive
    risk (the attribute name is Mellea-specific and reserved).
  
  ## Why

  LLM-generated pipelines sometimes use `Requirement` objects as
  general-purpose precondition checkers for `run_pipeline` input
  arguments. The misuse looks like:

  ```python
  checks = [
      (require_nonempty_contract, {"contract_pdf_text": contract_pdf_text}),
      ...
  ]
  for req, ctx in checks:
      if req.validation_fn is not None:
          result = req.validation_fn(ctx)   # ctx is a plain dict

  This compiles cleanly and passes Step 7 lints, then fails at smoke
  check with:

  AttributeError: 'dict' object has no attribute 'last_output'
  Two layers of misuse, one root cause:

  1. Conceptual — Requirement is designed to validate model
  outputs during a sampling loop, not to validate input arguments.
  The right Python idiom for input preconditions is
  if not x.strip(): raise ValueError(...).
  2. Mechanical — even when Requirement is the right tool, user
  code should not call req.validation_fn directly. The public API
  is req.validate(backend, ctx, ...). Calling validation_fn
  directly passes the wrong argument type (a dict where Mellea
  expects a Context); the wrapper inserted by simple_validate(fn)
  then calls ctx.last_output() on the dict and the AttributeError
  fires.
  
  The misuse is detectable from the AST alone — <expr>.validation_fn(...)
  is a reserved attribute name on Requirement and should never appear
  as a call site in user code.

  How

  lint_validation_fn_not_called_directly walks every *.py under
  <package>/ (skipping __pycache__/, intermediate/, fixtures/).
  For each ast.Call whose func is ast.Attribute with
  attr == "validation_fn", it records a failure with the rendered
  offending call.
  
  The failure message names both correct idioms inline:

  - For input-argument preconditions: plain if/raise ValueError(...).
  - For Requirement-based validation: req.validate(backend, ctx, ...)
  or attach the Requirement to a sampling strategy.

  No surface dependency, no type inference, no cross-file
  reasoning — single AST pass per file.

  Evidence

  Run against a real skill compile whose pipeline.py calls
  req.validation_fn(...) directly to "check" input arguments:

  verdict: fail
  files_checked: 9
  failures: 1 — `pipeline.py:<line>` cites the offending
              `req.validation_fn(...)` call, names the public API
              (`req.validate(backend, ctx, ...)`) and the plain-Python
              alternative for precondition checks.

  Run against a working pipeline that uses Requirement correctly (no
  direct .validation_fn calls): 

  verdict: pass
  files_checked: 9
  failures: 0

  Correctly inert when the misuse pattern isn't present.

  Files changed

  - src/mellea_skills_compiler/compile/lints.py — new
  lint_validation_fn_not_called_directly function + added to
  ALL_LINTS. +91 lines.
  - tests/mellea_skills_compiler/compile/test_lints.py — new
  TestValidationFnNotCalledDirectly class with 9 cases:
  bare-dict-fails, attribute-access-without-call passes, bare-name
  validation_fn(...) (local var, not attribute) passes,
  req.validate(backend, ctx) passes (the correct public API), other
  method names not flagged, multiple failures in one file all
  reported, path-skip (__pycache__/intermediate/fixtures),
  syntax-error files silently skipped, failure-message-points-to-
  correct-idiom. +116 lines.

  Test plan 

  - pytest tests/mellea_skills_compiler/compile/test_lints.py::TestValidationFnNotCalledDirectly
  — should pass 9 new cases.
  - pytest tests/ — full suite stays green.
  - Optional: compile any skill whose pipeline.py previously
  emitted req.validation_fn(...) as a precondition check —
  confirm Step 7 now blocks before smoke runs.