### PR TITLE
feat(lints): add fixture-pydantic-coercion to catch dict-vs-Pydantic param mismatch

### DIFF
--- a/src/mellea_skills_compiler/compile/lints.py
+++ b/src/mellea_skills_compiler/compile/lints.py
@@ -541,6 +541,193 @@ def lint_validation_fn_not_called_directly(package_dir: Path) -> LintResult:
     return result
 
 
+# ─── Lint: fixture-pydantic-coercion ───
+#
+# Cross-file check: fixture inputs must not pass bare dict literals where
+# ``run_pipeline``'s signature declares a Pydantic-typed parameter. The
+# fixture-shape mismatch raises ``AttributeError: 'dict' object has no
+# attribute '<field>'`` at smoke-check time.
+#
+# Detection-only. The durable structural fix lives in the fixtures writer
+# (have it emit ``Model(**{...})`` instead of raw ``{...}``); that's
+# tracked separately.
+
+
+def _find_pydantic_classes_in_schemas(schemas_py: Path) -> set:
+    """Return names of classes in schemas.py that transitively subclass BaseModel."""
+    if not schemas_py.is_file():
+        return set()
+    try:
+        tree = ast.parse(schemas_py.read_text())
+    except SyntaxError:
+        return set()
+
+    pydantic: set = set()
+
+    def _base_is_pydantic(base: ast.expr) -> bool:
+        if isinstance(base, ast.Name):
+            return base.id == "BaseModel" or base.id in pydantic
+        if isinstance(base, ast.Attribute) and base.attr == "BaseModel":
+            return True
+        return False
+
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef) or node.name in pydantic:
+                continue
+            if any(_base_is_pydantic(b) for b in node.bases):
+                pydantic.add(node.name)
+                changed = True
+    return pydantic
+
+
+def _resolve_pydantic_annotation(node: ast.expr, pydantic_classes: set) -> Optional[str]:
+    """Return the Pydantic class name if ``node`` annotates a Pydantic-typed param.
+
+    Handles: ``Foo``, ``Optional[Foo]``, ``Foo | None``.
+    """
+    if isinstance(node, ast.Name):
+        return node.id if node.id in pydantic_classes else None
+    if isinstance(node, ast.Subscript):
+        outer = node.value
+        if isinstance(outer, ast.Name) and outer.id == "Optional":
+            return _resolve_pydantic_annotation(node.slice, pydantic_classes)
+        return None
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _resolve_pydantic_annotation(node.left, pydantic_classes)
+        right = _resolve_pydantic_annotation(node.right, pydantic_classes)
+        return left or right
+    return None
+
+
+def _pydantic_typed_run_pipeline_params(
+    pipeline_py: Path, pydantic_classes: set
+) -> dict:
+    """Return ``{param_name: pydantic_class}`` for run_pipeline params typed as Pydantic."""
+    if not pipeline_py.is_file():
+        return {}
+    try:
+        tree = ast.parse(pipeline_py.read_text())
+    except SyntaxError:
+        return {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "run_pipeline":
+            continue
+        params: dict = {}
+        for arg in node.args.args:
+            if arg.annotation is None:
+                continue
+            cls = _resolve_pydantic_annotation(arg.annotation, pydantic_classes)
+            if cls is not None:
+                params[arg.arg] = cls
+        return params
+    return {}
+
+
+def _check_fixture_inputs(
+    fixture_py: Path, pydantic_params: dict
+) -> List[Tuple[str, Optional[int], Optional[int], str]]:
+    """Walk a fixture .py file; return (param_name, line, col, model_class) violations."""
+    if not fixture_py.is_file():
+        return []
+    try:
+        tree = ast.parse(fixture_py.read_text())
+    except SyntaxError:
+        return []
+
+    violations: List[Tuple[str, Optional[int], Optional[int], str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (
+            len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "inputs"
+            and isinstance(node.value, ast.Dict)
+        ):
+            continue
+        for k_node, v_node in zip(node.value.keys, node.value.values):
+            if not (isinstance(k_node, ast.Constant) and isinstance(k_node.value, str)):
+                continue
+            param_name = k_node.value
+            if param_name not in pydantic_params:
+                continue
+            if isinstance(v_node, ast.Dict):
+                violations.append(
+                    (
+                        param_name,
+                        getattr(v_node, "lineno", None),
+                        getattr(v_node, "col_offset", None),
+                        pydantic_params[param_name],
+                    )
+                )
+    return violations
+
+
+def lint_fixture_pydantic_coercion(package_dir: Path) -> LintResult:
+    """Fixture inputs must not pass bare dicts where run_pipeline expects Pydantic models."""
+    result = LintResult(lint_id="fixture-pydantic-coercion", verdict="pass")
+
+    pipeline_py = package_dir / "pipeline.py"
+    schemas_py = package_dir / "schemas.py"
+    fixtures_dir = package_dir / "fixtures"
+
+    if not pipeline_py.is_file():
+        result.verdict = "skipped"
+        result.skipped_reason = "pipeline.py not found"
+        return result
+    if not fixtures_dir.is_dir():
+        result.verdict = "skipped"
+        result.skipped_reason = "fixtures/ directory not found"
+        return result
+
+    pydantic_classes = _find_pydantic_classes_in_schemas(schemas_py)
+    pydantic_params = _pydantic_typed_run_pipeline_params(pipeline_py, pydantic_classes)
+
+    if not pydantic_params:
+        return result
+
+    fixture_files = sorted(
+        p for p in fixtures_dir.glob("*.py") if p.name != "__init__.py"
+    )
+    result.files_checked = len(fixture_files)
+
+    for fixture_py in fixture_files:
+        for param_name, line, col, model_class in _check_fixture_inputs(
+            fixture_py, pydantic_params
+        ):
+            result.failures.append(
+                LintFailure(
+                    file=f"fixtures/{fixture_py.name}",
+                    line=line,
+                    column=col,
+                    message=(
+                        f"Fixture passes `{param_name}=<bare dict>` but "
+                        f"`run_pipeline.{param_name}` is typed as "
+                        f"`{model_class}` (Pydantic). At smoke-check time "
+                        f"the first attribute access on `{param_name}` "
+                        f"raises `AttributeError: 'dict' object has no "
+                        f"attribute ...`. Fix either side: (a) construct "
+                        f"the model in the fixture — "
+                        f"`'{param_name}': {model_class}(**{{...}})`; "
+                        f"(b) coerce at the pipeline entry — "
+                        f"`if isinstance({param_name}, dict): "
+                        f"{param_name} = {model_class}(**{param_name})`. "
+                        f"The durable structural fix is writer-side "
+                        f"(see lint header comment)."
+                    ),
+                    rule_ref="fixture-pydantic-coercion",
+                )
+            )
+
+    if result.failures:
+        result.verdict = "fail"
+    return result
+
+
 # ─── Runner ───
 
 
@@ -550,6 +737,7 @@ ALL_LINTS: Tuple[Callable[[Path], LintResult], ...] = (
     lint_runtime_defaults_bound,
     lint_session_method_arity,
     lint_validation_fn_not_called_directly,
+    lint_fixture_pydantic_coercion,
 )
 
 

--- a/tests/mellea_skills_compiler/compile/test_lints.py
+++ b/tests/mellea_skills_compiler/compile/test_lints.py
@@ -17,6 +17,7 @@ from typing import Dict
 
 from mellea_skills_compiler.compile.lints import (
     lint_bundled_asset_path_resolution,
+    lint_fixture_pydantic_coercion,
     lint_fixtures_loader_contract,
     lint_runtime_defaults_bound,
     lint_session_method_arity,
@@ -786,3 +787,273 @@ class TestValidationFnNotCalledDirectly:
             msg = result.failures[0].message
             assert "req.validate" in msg
             assert "ValueError" in msg
+
+
+# ─── TestFixturePydanticCoercion ───
+
+
+_SCHEMAS_PY = (
+    "from pydantic import BaseModel\n"
+    "from typing import Optional\n"
+    "\n"
+    "class IntakeContext(BaseModel):\n"
+    "    sport: str\n"
+    "    institution: str\n"
+    "\n"
+    "class ReviewMemorandum(BaseModel):\n"
+    "    findings: list[str]\n"
+)
+
+_PIPELINE_WITH_PYDANTIC_PARAM = (
+    "from .schemas import IntakeContext, ReviewMemorandum\n"
+    "from typing import Optional\n"
+    "\n"
+    "def run_pipeline(contract_text: str, intake: IntakeContext) -> ReviewMemorandum:\n"
+    "    return ReviewMemorandum(findings=[intake.sport])\n"
+)
+
+_PIPELINE_WITHOUT_PYDANTIC_PARAM = (
+    "def run_pipeline(user_query: str) -> str:\n"
+    "    return user_query\n"
+)
+
+
+class TestFixturePydanticCoercion:
+    """Test cases for lint_fixture_pydantic_coercion."""
+
+    def test_bare_dict_for_pydantic_param_fails_nil_contract_reproducer(self):
+        """The exact nil-contract bug: fixture passes intake as a bare dict."""
+        fixture = (
+            'def make_x():\n'
+            '    inputs = {\n'
+            '        "contract_text": "txt",\n'
+            '        "intake": {"sport": "Football", "institution": "U.Fla"},\n'
+            '    }\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": _SCHEMAS_PY,
+                    "pipeline.py": _PIPELINE_WITH_PYDANTIC_PARAM,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            result = lint_fixture_pydantic_coercion(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 1
+            assert "intake" in result.failures[0].message
+            assert "IntakeContext" in result.failures[0].message
+
+    def test_model_constructor_call_passes(self):
+        fixture = (
+            'def make_x():\n'
+            '    inputs = {\n'
+            '        "contract_text": "txt",\n'
+            '        "intake": IntakeContext(**{"sport": "F", "institution": "U"}),\n'
+            '    }\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": _SCHEMAS_PY,
+                    "pipeline.py": _PIPELINE_WITH_PYDANTIC_PARAM,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "pass"
+
+    def test_variable_reference_passes(self):
+        fixture = (
+            'def make_x():\n'
+            '    ctx = IntakeContext(sport="F", institution="U")\n'
+            '    inputs = {"contract_text": "txt", "intake": ctx}\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": _SCHEMAS_PY,
+                    "pipeline.py": _PIPELINE_WITH_PYDANTIC_PARAM,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "pass"
+
+    def test_non_pydantic_param_dict_value_ignored(self):
+        fixture = (
+            'def make_x():\n'
+            '    inputs = {"user_query": "hello"}\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "pipeline.py": _PIPELINE_WITHOUT_PYDANTIC_PARAM,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "pass"
+
+    def test_optional_pydantic_param_dict_value_fails(self):
+        pipeline = (
+            "from .schemas import IntakeContext, ReviewMemorandum\n"
+            "from typing import Optional\n"
+            "\n"
+            "def run_pipeline(intake: Optional[IntakeContext] = None) -> str:\n"
+            "    return intake.sport if intake else ''\n"
+        )
+        fixture = (
+            'def make_x():\n'
+            '    inputs = {"intake": {"sport": "F", "institution": "U"}}\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": _SCHEMAS_PY,
+                    "pipeline.py": pipeline,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "fail"
+
+    def test_pipe_or_none_pydantic_param_dict_value_fails(self):
+        pipeline = (
+            "from .schemas import IntakeContext, ReviewMemorandum\n"
+            "\n"
+            "def run_pipeline(intake: IntakeContext | None = None) -> str:\n"
+            "    return intake.sport if intake else ''\n"
+        )
+        fixture = (
+            'def make_x():\n'
+            '    inputs = {"intake": {"sport": "F", "institution": "U"}}\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": _SCHEMAS_PY,
+                    "pipeline.py": pipeline,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "fail"
+
+    def test_transitive_pydantic_subclass_detected(self):
+        schemas = (
+            "from pydantic import BaseModel\n"
+            "class Foo(BaseModel):\n"
+            "    a: str\n"
+            "class Bar(Foo):\n"
+            "    b: str\n"
+        )
+        pipeline = (
+            "from .schemas import Bar\n"
+            "def run_pipeline(bar: Bar) -> str:\n"
+            "    return bar.a\n"
+        )
+        fixture = (
+            'def make_x():\n'
+            '    inputs = {"bar": {"a": "x", "b": "y"}}\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": schemas,
+                    "pipeline.py": pipeline,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "fail"
+
+    def test_pipeline_missing_returns_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = Path(tmp)
+            (pkg / "fixtures").mkdir()
+            (pkg / "fixtures" / "__init__.py").write_text("ALL_FIXTURES = []\n")
+            result = lint_fixture_pydantic_coercion(pkg)
+            assert result.verdict == "skipped"
+            assert "pipeline.py" in (result.skipped_reason or "")
+
+    def test_fixtures_dir_missing_returns_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {"pipeline.py": _PIPELINE_WITHOUT_PYDANTIC_PARAM},
+            )
+            result = lint_fixture_pydantic_coercion(pkg)
+            assert result.verdict == "skipped"
+
+    def test_schemas_missing_no_false_positive(self):
+        fixture = (
+            'def make_x():\n'
+            '    inputs = {"intake": {"sport": "F"}}\n'
+            '    return inputs, "x", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "pipeline.py": _PIPELINE_WITH_PYDANTIC_PARAM,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": fixture,
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "pass"
+
+    def test_syntax_error_in_fixture_silently_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": _SCHEMAS_PY,
+                    "pipeline.py": _PIPELINE_WITH_PYDANTIC_PARAM,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/x.py": "def broken(:\n    pass\n",
+                },
+            )
+            assert lint_fixture_pydantic_coercion(pkg).verdict == "pass"
+
+    def test_multiple_fixtures_mixed_results(self):
+        good = (
+            'def make_g():\n'
+            '    inputs = {"intake": IntakeContext(sport="F", institution="U")}\n'
+            '    return inputs, "g", "desc"\n'
+        )
+        bad = (
+            'def make_b():\n'
+            '    inputs = {"intake": {"sport": "F", "institution": "U"}}\n'
+            '    return inputs, "b", "desc"\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {
+                    "schemas.py": _SCHEMAS_PY,
+                    "pipeline.py": _PIPELINE_WITH_PYDANTIC_PARAM,
+                    "fixtures/__init__.py": "ALL_FIXTURES = []\n",
+                    "fixtures/g.py": good,
+                    "fixtures/b.py": bad,
+                },
+            )
+            result = lint_fixture_pydantic_coercion(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 1
+            assert result.failures[0].file == "fixtures/b.py"


### PR DESCRIPTION
 ## Summary

  - New Step 7 lint `fixture-pydantic-coercion`. AST-walks `schemas.py`
    to discover Pydantic `BaseModel` subclasses, `pipeline.py` to extract
    `run_pipeline` params typed as those classes, and `fixtures/<id>.py`
    to flag inputs that pass a bare dict literal where a Pydantic-typed
    param is expected.
  - Pure-AST cross-reference; no runtime introspection, no type-checker
    dependency.
  - Detection-only — the lint surfaces the symptom at Step 7 before the
    smoke check runs. A durable structural alternative (writer-side
    coercion) is described in the Follow-ups section.
  
  ## Why

  Skills whose `pipeline.py` declares a Pydantic-typed `run_pipeline`
  parameter (e.g. `intake: IntakeContext`) and whose fixtures emit raw
  dicts for that parameter (e.g. `'intake': {'sport': '...', ...}`) compile
  cleanly but fail at smoke-check time:

      AttributeError: 'dict' object has no attribute 'sport'

  The fixture is rendered from `fixtures_emission.json`, which only carries
  JSON-serialisable values. The deterministic
  `.claude/melleafy/writers/fixtures_writer.py` emits each input as a
  Python literal — bare dicts stay as bare dicts. At smoke-check time
  `pipeline_fn(**inputs)` passes `intake` as `dict`, and the first
  attribute access on it raises `AttributeError`.

  The defect is detectable from the AST alone: `schemas.py` + `pipeline.py`
  together describe which parameters are Pydantic-typed; each fixture
  file makes its own input shapes statically visible. Cross-referencing
  the two gives an exact, actionable failure report at Step 7.

  ## How

  Three AST passes, one file each:
  
  1. **`_find_pydantic_classes_in_schemas(schemas.py)`** — collects class
     definitions that transitively inherit from `BaseModel` (direct
     subclass or subclass-of-subclass; closure under transitive
     inheritance).
  2. **`_pydantic_typed_run_pipeline_params(pipeline.py, ...)`** — locates
     `def run_pipeline(...)` and resolves each annotated argument to a
     Pydantic class name. Handles `Foo`, `Optional[Foo]`, and `Foo | None`.
     Returns `None` for `list[Foo]` and similar containers (out of scope).
  3. **`_check_fixture_inputs(fixtures/<id>.py, params)`** — for each
     `inputs = {...}` dict literal in the fixture, flags any value that is
     a bare `ast.Dict` whose key matches a Pydantic-typed param. Variable
     references, model constructor calls (`IntakeContext(**{...})`), and
     indeterminate expressions pass without firing — keeping the false-
     positive rate near zero.
  
  The lint runs in the existing `ALL_LINTS` flow during the wrapper's
  post-session `validate()`; the writer has already rendered
  `fixtures/<id>.py` by that point, so the AST walk is straightforward.

  The failure message names both quick fixes inline:

  - Construct the model in the fixture: `'intake': IntakeContext(**{...})`
  - Coerce at the pipeline entry: `if isinstance(intake, dict): intake = IntakeContext(**intake)`

 ## Files changed

  - `src/mellea_skills_compiler/compile/lints.py` — new
    `lint_fixture_pydantic_coercion` + four helpers
    (`_find_pydantic_classes_in_schemas`, `_resolve_pydantic_annotation`,
    `_pydantic_typed_run_pipeline_params`, `_check_fixture_inputs`).
    Lint header explicitly documents the writer-side alternative (see
    Follow-ups). Added to `ALL_LINTS`. +206 lines.
  - `tests/mellea_skills_compiler/compile/test_lints.py` — new
    `TestFixturePydanticCoercion` class with 12 cases: bare-dict-fails
    (the nil-contract reproducer), constructor-passes,
    variable-ref-passes, non-Pydantic-param-ignored, `Optional[Model]`
    handled, `Model | None` handled, transitive Pydantic subclass
    detection, pipeline-missing → skipped, fixtures-dir-missing → skipped,
    schemas-missing → no false positive, syntax-error-in-fixture silently
    skipped, multiple fixtures with mixed pass/fail. +271 lines.
  
  ## Test plan

  - [ ] `pytest tests/mellea_skills_compiler/compile/test_lints.py::TestFixturePydanticCoercion`
        — should pass 12 new cases.
  - [ ] `pytest tests/` — full suite stays green.
  - [ ] Optional: compile any skill whose `run_pipeline` declares a
        Pydantic-typed parameter, with fixtures that pass that parameter
        as a bare dict — confirm Step 7 now blocks the offending fixtures
        before smoke runs, with an actionable message naming the fixture,
        param, and model class.