### PR TITLE
feat(lints): add instruct-result-parse-before-access, format-annotation, session-boundary

### DIFF
--- a/src/mellea_skills_compiler/compile/lints.py
+++ b/src/mellea_skills_compiler/compile/lints.py
@@ -1,15 +1,9 @@
 """Step 7 structural lints — Python implementations.
 
-Implements two lints from `.claude/commands/mellea-fy-validate.md`:
-
-  - `bundled-asset-path-resolution` (Rule OUT-6, Rule 2.5-2)
-  - `fixtures-loader-contract` (R16, Rule 4-1)
-
-The other 14 lints documented in `mellea-fy-validate.md` are still applied
-by the LLM during Step 7 of the slash command. These two are implemented in
-Python because they are AST-precise structural checks where LLM application
-has proven unreliable, and they catch the exact drift modes that have caused
-post-compile breakage in shipped skills (see session history).
+AST-precise structural checks where LLM application has proven unreliable
+and the drift modes have caused post-compile breakage in shipped skills.
+The remaining lints documented in `.claude/commands/mellea-fy-validate.md`
+are still applied by the LLM during Step 7 of the slash command.
 """
 
 from __future__ import annotations
@@ -19,10 +13,23 @@ import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Set, Tuple
 
 
 _BUNDLED_DIRS = ("scripts", "references", "assets")
+
+
+def _col_offset_to_schema(node: Any) -> Optional[int]:
+    """Convert an AST node's 0-indexed ``col_offset`` to a 1-indexed column.
+
+    Python's ``ast.AST.col_offset`` is 0-indexed. LSP/IDE conventions and the
+    step_7_report schema treat ``column`` as 1-indexed. Returns ``None`` when
+    the node lacks the attribute.
+    """
+    col = getattr(node, "col_offset", None)
+    if col is None:
+        return None
+    return col + 1
 
 
 @dataclass
@@ -471,6 +478,514 @@ def lint_session_method_arity(package_dir: Path) -> LintResult:
     return result
 
 
+# ─── Shared helpers: m.instruct / start_session pattern detection ───
+#
+# Used by instruct-result-parse-before-access, format-annotation, and
+# session-boundary. The three lints share the same surface (pipeline.py,
+# slots.py, constrained_slots.py) and the same notion of an "m.instruct(...)"
+# call assigned to a Name target.
+
+
+_INSTRUCT_LINT_FILES: Tuple[str, ...] = (
+    "pipeline.py",
+    "slots.py",
+    "constrained_slots.py",
+)
+
+
+def _is_m_instruct_call(node: ast.AST) -> bool:
+    """True iff node is a `Call` whose func is `m.instruct` (Attribute on Name 'm')."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "instruct":
+        return False
+    return isinstance(func.value, ast.Name) and func.value.id == "m"
+
+
+def _instruct_call_has_format_kwarg(node: ast.Call) -> bool:
+    """True iff an `m.instruct(...)` Call has a `format=` keyword."""
+    return any(kw.arg == "format" for kw in node.keywords)
+
+
+def _iter_function_scopes(tree: ast.AST):
+    """Yield every FunctionDef/AsyncFunctionDef + the module-level scope."""
+    yield tree
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+# ─── Lint: instruct-result-parse-before-access (KB1) ───
+#
+# `m.instruct(format=Model)` returns a `ComputedModelOutputThunk`, not a
+# Pydantic model. Direct attribute access on the thunk (`thunk.some_field`)
+# raises AttributeError at runtime. The thunk must be parsed first via
+# `_safe_parse_with_fallback`, `_parse_instruct_result`, or
+# `Model.model_validate_json(thunk.value)`.
+
+
+_THUNK_CONSUMER_FUNC_NAMES: frozenset = frozenset({
+    "_parse_instruct_result",
+    "_safe_parse_with_fallback",
+})
+
+
+def _consumer_thunk_arg_nodes(call: ast.Call, raw_thunks: Set[str]) -> Set[int]:
+    """Return id(arg_node) set for thunk-Name args sitting in the first
+    positional slot of a documented parser call."""
+    fname = (
+        call.func.id if isinstance(call.func, ast.Name)
+        else call.func.attr if isinstance(call.func, ast.Attribute)
+        else None
+    )
+    if fname not in _THUNK_CONSUMER_FUNC_NAMES:
+        return set()
+    if not call.args:
+        return set()
+    first = call.args[0]
+    if isinstance(first, ast.Name) and first.id in raw_thunks:
+        return {id(first)}
+    return set()
+
+
+def _is_model_validate_json_on_thunk_value(
+    call: ast.Call, raw_thunks: Set[str]
+) -> Optional[str]:
+    """If call is `Model.model_validate_json(thunk.value)` for a known thunk,
+    return the thunk's name; otherwise None."""
+    func = call.func
+    if not (
+        isinstance(func, ast.Attribute) and func.attr == "model_validate_json"
+    ):
+        return None
+    if len(call.args) != 1:
+        return None
+    arg = call.args[0]
+    if not (isinstance(arg, ast.Attribute) and arg.attr == "value"):
+        return None
+    inner = arg.value
+    if isinstance(inner, ast.Name) and inner.id in raw_thunks:
+        return inner.id
+    return None
+
+
+def _stmt_assigns_from_consumer(
+    stmt: ast.stmt, raw_thunks: Set[str]
+) -> Optional[Tuple[str, ast.Call]]:
+    """If stmt is `var = consumer(thunk, ...)`, return (var_name, call)."""
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if not isinstance(target, ast.Name):
+        return None
+    call = stmt.value
+    if not isinstance(call, ast.Call):
+        return None
+    fname = (
+        call.func.id if isinstance(call.func, ast.Name)
+        else call.func.attr if isinstance(call.func, ast.Attribute)
+        else None
+    )
+    if fname not in _THUNK_CONSUMER_FUNC_NAMES:
+        return None
+    if not call.args:
+        return None
+    first = call.args[0]
+    if not (isinstance(first, ast.Name) and first.id in raw_thunks):
+        return None
+    return target.id, call
+
+
+def _scan_scope_for_kb1(
+    scope: ast.AST, rel: str, failures: List[LintFailure]
+) -> None:
+    """Walk one function body statement-by-statement, tracking raw thunks."""
+    raw_thunks: Set[str] = set()
+    body = getattr(scope, "body", [])
+
+    def _process_block(stmts):
+        nonlocal raw_thunks
+        for stmt in stmts:
+            new_thunk_name: Optional[str] = None
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and isinstance(stmt.value, ast.Call)
+                and _is_m_instruct_call(stmt.value)
+                and _instruct_call_has_format_kwarg(stmt.value)
+            ):
+                new_thunk_name = stmt.targets[0].id
+
+            consumed = _stmt_assigns_from_consumer(stmt, raw_thunks)
+
+            exempt_node_ids: Set[int] = set()
+            for sub in ast.walk(stmt):
+                if isinstance(sub, ast.Call):
+                    exempt_node_ids |= _consumer_thunk_arg_nodes(sub, raw_thunks)
+                    thunk_in_mvj = _is_model_validate_json_on_thunk_value(
+                        sub, raw_thunks
+                    )
+                    if thunk_in_mvj is not None:
+                        arg = sub.args[0]
+                        exempt_node_ids.add(id(arg))
+                        exempt_node_ids.add(id(arg.value))
+
+            for sub in ast.walk(stmt):
+                if isinstance(sub, ast.Attribute):
+                    base = sub.value
+                    if not (
+                        isinstance(base, ast.Name) and base.id in raw_thunks
+                    ):
+                        continue
+                    if id(sub) in exempt_node_ids:
+                        continue
+                    failures.append(
+                        LintFailure(
+                            file=rel,
+                            line=getattr(sub, "lineno", None),
+                            column=getattr(sub, "col_offset", None),
+                            message=(
+                                f"`{base.id}` is the result of "
+                                f"`m.instruct(..., format=Model)` and is a "
+                                f"`ComputedModelOutputThunk`, NOT a Pydantic "
+                                f"model. Direct attribute access "
+                                f"`{base.id}.{sub.attr}` raises AttributeError"
+                                f" at runtime (KB1). Parse the thunk first: "
+                                f"`parsed = _safe_parse_with_fallback("
+                                f"{base.id}, <Model>, **defaults)` (preferred)"
+                                f", `parsed = _parse_instruct_result("
+                                f"{base.id}, <Model>)`, or `<Model>."
+                                f"model_validate_json({base.id}.value)`."
+                            ),
+                            rule_ref="KB1 (instruct returns thunk)",
+                        )
+                    )
+
+            if consumed is not None:
+                consumed_var, _ = consumed
+                call = stmt.value
+                first_arg = call.args[0]
+                if isinstance(first_arg, ast.Name):
+                    raw_thunks.discard(first_arg.id)
+                raw_thunks.discard(consumed_var)
+            elif new_thunk_name is not None:
+                raw_thunks.add(new_thunk_name)
+            else:
+                if isinstance(stmt, ast.Assign):
+                    for tgt in stmt.targets:
+                        if isinstance(tgt, ast.Name):
+                            raw_thunks.discard(tgt.id)
+
+            for attr in ("body", "orelse", "finalbody"):
+                inner = getattr(stmt, attr, None)
+                if isinstance(inner, list):
+                    _process_block(inner)
+            if isinstance(stmt, ast.Try):
+                for handler in stmt.handlers:
+                    _process_block(handler.body)
+
+    _process_block(body)
+
+
+def lint_instruct_result_parse_before_access(package_dir: Path) -> LintResult:
+    """KB1: `m.instruct(format=Model)` returns a thunk, not a Pydantic model.
+
+    The thunk MUST be parsed before any field access. Exempt patterns:
+      - `_parse_instruct_result(thunk, M)`
+      - `_safe_parse_with_fallback(thunk, M, **defaults)`
+      - `M.model_validate_json(thunk.value)`
+    """
+    result = LintResult(
+        lint_id="instruct-result-parse-before-access", verdict="pass"
+    )
+
+    files_to_check: List[Path] = []
+    for fname in _INSTRUCT_LINT_FILES:
+        p = package_dir / fname
+        if p.exists():
+            files_to_check.append(p)
+    result.files_checked = len(files_to_check)
+
+    for py_file in files_to_check:
+        rel = py_file.relative_to(package_dir).as_posix()
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+        for scope in _iter_function_scopes(tree):
+            _scan_scope_for_kb1(scope, rel, result.failures)
+
+    seen: Set[Tuple[str, Optional[int], Optional[int], str]] = set()
+    deduped: List[LintFailure] = []
+    for f in result.failures:
+        key = (f.file, f.line, f.column, f.message[:80])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(f)
+    result.failures = deduped
+
+    if result.failures:
+        result.verdict = "fail"
+    return result
+
+
+# ─── Lint: format-annotation ───
+#
+# Every `m.instruct(...)` call whose result is later parsed (via
+# `Model.model_validate_json(thunk.value)`, `_parse_instruct_result(thunk, Model)`,
+# or `_safe_parse_with_fallback(thunk, Model, ...)`) MUST carry a `format=`
+# keyword. Without it, the LLM returns free-form JSON-shaped text instead of
+# constrained-decoding output, and the Pydantic parse fails (or worse, silently
+# succeeds on a poorly-shaped JSON object).
+
+
+def lint_format_annotation(package_dir: Path) -> LintResult:
+    """`m.instruct(...)` calls whose result is parsed must include `format=`.
+
+    Detection:
+      1. AST-parse pipeline.py / slots.py / constrained_slots.py.
+      2. For every `Call` that is `m.instruct(...)` assigned to a Name target
+         (`thunk = m.instruct(...)`), record whether it has `format=` and
+         which variable holds the result.
+      3. Walk for subsequent uses of that variable as:
+           - argument to `<Model>.model_validate_json(<thunk>.value)`
+           - first positional arg to `_parse_instruct_result(<thunk>, ...)`
+           - first positional arg to `_safe_parse_with_fallback(<thunk>, ...)`
+      4. If any such parse-use is found AND the original instruct call had
+         no `format=` kwarg → hard failure on the m.instruct call line.
+    """
+    result = LintResult(lint_id="format-annotation", verdict="pass")
+
+    files_to_check: List[Path] = []
+    for fname in _INSTRUCT_LINT_FILES:
+        p = package_dir / fname
+        if p.exists():
+            files_to_check.append(p)
+    result.files_checked = len(files_to_check)
+
+    for py_file in files_to_check:
+        rel = py_file.relative_to(package_dir).as_posix()
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        instruct_assignments: dict = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, ast.Name):
+                continue
+            if not (
+                isinstance(node.value, ast.Call) and _is_m_instruct_call(node.value)
+            ):
+                continue
+            instruct_assignments[target.id] = (
+                _instruct_call_has_format_kwarg(node.value),
+                node.value,
+            )
+
+        if not instruct_assignments:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+
+            # Pattern 1: <Model>.model_validate_json(thunk.value)
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "model_validate_json"
+                and len(node.args) == 1
+                and isinstance(node.args[0], ast.Attribute)
+                and node.args[0].attr == "value"
+                and isinstance(node.args[0].value, ast.Name)
+            ):
+                thunk_name = node.args[0].value.id
+                info = instruct_assignments.get(thunk_name)
+                if info and not info[0]:
+                    instruct_call = info[1]
+                    result.failures.append(
+                        LintFailure(
+                            file=rel,
+                            line=getattr(instruct_call, "lineno", None),
+                            column=getattr(instruct_call, "col_offset", None),
+                            message=(
+                                f"m.instruct() result `{thunk_name}` is "
+                                f"parsed via `<Model>.model_validate_json"
+                                f"({thunk_name}.value)` but the m.instruct "
+                                f"call has no `format=` keyword. Without "
+                                f"`format=`, the model returns free-form "
+                                f"text instead of constrained-decoded JSON; "
+                                f"the parse will fail or silently produce "
+                                f"a malformed object. Fix: add "
+                                f"`format=<Model>` to the m.instruct call."
+                            ),
+                            rule_ref="format-annotation",
+                        )
+                    )
+                continue
+
+            # Patterns 2/3: _parse_instruct_result(thunk, ...) or
+            # _safe_parse_with_fallback(thunk, ...)
+            callee = (
+                func.id if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute)
+                else None
+            )
+            if callee not in (
+                "_parse_instruct_result",
+                "_safe_parse_with_fallback",
+            ):
+                continue
+            if not node.args:
+                continue
+            first = node.args[0]
+            if not isinstance(first, ast.Name):
+                continue
+            info = instruct_assignments.get(first.id)
+            if info and not info[0]:
+                instruct_call = info[1]
+                result.failures.append(
+                    LintFailure(
+                        file=rel,
+                        line=getattr(instruct_call, "lineno", None),
+                        column=getattr(instruct_call, "col_offset", None),
+                        message=(
+                            f"m.instruct() result `{first.id}` is parsed "
+                            f"via `{callee}({first.id}, ...)` but the "
+                            f"m.instruct call has no `format=` keyword. "
+                            f"Without `format=`, the model returns free-"
+                            f"form text and the helper's "
+                            f"`model_validate_json` call inside will fail. "
+                            f"Fix: add `format=<Model>` to the m.instruct "
+                            f"call."
+                        ),
+                        rule_ref="format-annotation",
+                    )
+                )
+
+    seen: Set[Tuple[str, Optional[int]]] = set()
+    deduped: List[LintFailure] = []
+    for f in result.failures:
+        key = (f.file, f.line)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(f)
+    result.failures = deduped
+
+    if result.failures:
+        result.verdict = "fail"
+    return result
+
+
+# ─── Lint: session-boundary (KB5) ───
+#
+# Mellea schema priming: once a session has generated N objects matching schema
+# A, the next `m.instruct(format=B)` call in the same session keeps producing
+# A-shaped output. The fix is to split the session — open a new
+# `start_session()` block per distinct format type.
+
+
+def _is_start_session_call(node: ast.AST) -> bool:
+    """True iff node is a Call whose callee is the name `start_session`."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "start_session"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "start_session"
+    return False
+
+
+def _instruct_format_type_name(node: ast.Call) -> Optional[str]:
+    """If `node` is `<...>.instruct(format=X)`, return X's type name (or None)."""
+    if not (
+        isinstance(node.func, ast.Attribute) and node.func.attr == "instruct"
+    ):
+        return None
+    for kw in node.keywords:
+        if kw.arg != "format":
+            continue
+        if isinstance(kw.value, ast.Name):
+            return kw.value.id
+        if isinstance(kw.value, ast.Attribute):
+            return kw.value.attr
+    return None
+
+
+def lint_session_boundary(package_dir: Path) -> LintResult:
+    """Each `start_session(...)` block must use at most one distinct format type."""
+    result = LintResult(lint_id="session-boundary", verdict="pass")
+
+    files_to_check: List[Path] = []
+    for fname in _INSTRUCT_LINT_FILES:
+        p = package_dir / fname
+        if p.exists():
+            files_to_check.append(p)
+    result.files_checked = len(files_to_check)
+
+    for py_file in files_to_check:
+        rel = py_file.relative_to(package_dir).as_posix()
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.With, ast.AsyncWith)):
+                continue
+            is_session = any(
+                _is_start_session_call(item.context_expr) for item in node.items
+            )
+            if not is_session:
+                continue
+
+            format_types: Set[str] = set()
+            for child in ast.walk(node):
+                if not isinstance(child, ast.Call):
+                    continue
+                name = _instruct_format_type_name(child)
+                if name is not None:
+                    format_types.add(name)
+
+            if len(format_types) <= 1:
+                continue
+
+            result.failures.append(
+                LintFailure(
+                    file=rel,
+                    line=getattr(node, "lineno", None),
+                    column=getattr(node, "col_offset", None),
+                    message=(
+                        f"start_session() block uses {len(format_types)} "
+                        f"distinct format types: "
+                        f"{', '.join(sorted(format_types))}. Mellea's schema "
+                        f"priming means the LLM cannot reliably switch "
+                        f"BaseModel schemas mid-session — after N successful "
+                        f"generations of schema A, calls with format=B keep "
+                        f"producing A-shaped output. Fix: split into "
+                        f"separate `with start_session(...) as m:` blocks, "
+                        f"one per distinct format type."
+                    ),
+                    rule_ref="KB5 (session schema priming)",
+                )
+            )
+
+    if result.failures:
+        result.verdict = "fail"
+    return result
+
+
 # ─── Lint: validation-fn-not-called-directly ───
 #
 # Mellea's ``Requirement.validation_fn`` is internal sampling-loop plumbing.
@@ -728,6 +1243,8 @@ def lint_fixture_pydantic_coercion(package_dir: Path) -> LintResult:
     return result
 
 
+
+
 # ─── Runner ───
 
 
@@ -736,6 +1253,9 @@ ALL_LINTS: Tuple[Callable[[Path], LintResult], ...] = (
     lint_bundled_asset_path_resolution,
     lint_runtime_defaults_bound,
     lint_session_method_arity,
+    lint_instruct_result_parse_before_access,
+    lint_format_annotation,
+    lint_session_boundary,
     lint_validation_fn_not_called_directly,
     lint_fixture_pydantic_coercion,
 )

--- a/tests/mellea_skills_compiler/compile/test_lints.py
+++ b/tests/mellea_skills_compiler/compile/test_lints.py
@@ -1,11 +1,9 @@
 """Unit tests for mellea_skills_compiler.compile.lints module.
 
-Tests the three Step 7 structural lints (fixtures-loader-contract,
-bundled-asset-path-resolution, runtime-defaults-bound) plus the run_lints
-runner that emits intermediate/step_7_report.json.
-
-All tests construct synthetic skill packages on disk in tempfile.TemporaryDirectory
-contexts; no network, Ollama, or slash-command invocation.
+Covers every implemented Step 7 structural lint plus the run_lints runner
+that emits intermediate/step_7_report.json. All tests construct synthetic
+skill packages on disk in tempfile.TemporaryDirectory contexts; no network,
+Ollama, or slash-command invocation.
 """
 
 from __future__ import annotations
@@ -19,7 +17,10 @@ from mellea_skills_compiler.compile.lints import (
     lint_bundled_asset_path_resolution,
     lint_fixture_pydantic_coercion,
     lint_fixtures_loader_contract,
+    lint_format_annotation,
+    lint_instruct_result_parse_before_access,
     lint_runtime_defaults_bound,
+    lint_session_boundary,
     lint_session_method_arity,
     lint_validation_fn_not_called_directly,
     run_lints,
@@ -493,10 +494,17 @@ class TestRunLints:
             "from pathlib import Path\n"
             "p = Path(__file__).parent / 'scripts' / 'bash' / 'x.sh'\n"
         )
+        pipeline = "def run_pipeline(x: str) -> str:\n    return x\n"
         with tempfile.TemporaryDirectory() as tmp:
+            # The Tier 1 `parseable` lint requires <pkg>/pipeline.py to
+            # exist and import cleanly; a "compliant package" must include
+            # it. We materialise the package under an `_mellea`-suffixed
+            # parent so the subprocess `import <pkg>.pipeline` resolves.
             pkg = _make_package(
-                Path(tmp),
+                Path(tmp) / "synthetic_mellea",
                 {
+                    "__init__.py": "",
+                    "pipeline.py": pipeline,
                     "fixtures/__init__.py": "ALL_FIXTURES = []\n",
                     "config.py": config,
                     "tools.py": tools,
@@ -769,24 +777,470 @@ class TestValidationFnNotCalledDirectly:
                     "pipeline.py": "def y():\n    pass\n",
                 },
             )
-            assert lint_validation_fn_not_called_directly(pkg).verdict == "pass"
 
-    def test_syntax_error_file_silently_skipped(self):
-        content = "def broken(:\n    pass\n"
-        with tempfile.TemporaryDirectory() as tmp:
-            pkg = _make_package(Path(tmp), {"pipeline.py": content})
-            result = lint_validation_fn_not_called_directly(pkg)
-            assert result.verdict in ("pass", "skipped")
 
-    def test_failure_message_guides_to_correct_idiom(self):
-        content = "def x():\n    req.validation_fn(ctx)\n"
+# ─── TestInstructResultParseBeforeAccess ───
+
+
+class TestInstructResultParseBeforeAccess:
+    """Test cases for lint_instruct_result_parse_before_access (KB1)."""
+
+    _HELPERS = (
+        "def _parse_instruct_result(thunk, model_class):\n"
+        "    return model_class.model_validate_json(thunk.value)\n"
+        "def _safe_parse_with_fallback(thunk, model_class, **fb):\n"
+        "    try: return model_class.model_validate_json(thunk.value)\n"
+        "    except Exception: return model_class(**fb)\n"
+    )
+
+    def test_passes_with_parse_instruct_result(self):
+        pipeline = self._HELPERS + (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    intent = _parse_instruct_result(thunk, Intent)\n"
+            "    return intent.query_type\n"
+        )
         with tempfile.TemporaryDirectory() as tmp:
-            pkg = _make_package(Path(tmp), {"pipeline.py": content})
-            result = lint_validation_fn_not_called_directly(pkg)
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+    def test_passes_with_safe_parse_with_fallback(self):
+        pipeline = self._HELPERS + (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    intent = _safe_parse_with_fallback(thunk, Intent, query_type='x')\n"
+            "    return intent.query_type\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+    def test_passes_with_model_validate_json_value(self):
+        pipeline = self._HELPERS + (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    parsed = Intent.model_validate_json(thunk.value)\n"
+            "    return parsed.query_type\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+    def test_fails_with_direct_field_access(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    return thunk.query_type\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_instruct_result_parse_before_access(pkg)
+            assert result.verdict == "fail"
+            assert "thunk" in result.failures[0].message
+
+    def test_fails_with_model_dump_call(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        t = m.instruct('go', format=Intent)\n"
+            "    return t.model_dump()\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_instruct_result_parse_before_access(pkg)
+            assert result.verdict == "fail"
+
+    def test_fails_with_parsed_repr_access(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        t = m.instruct('go', format=Intent)\n"
+            "    x = t.parsed_repr\n"
+            "    return x\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "fail"
+            )
+
+    def test_passes_with_access_on_reassigned_parsed_var(self):
+        pipeline = self._HELPERS + (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    parsed = _safe_parse_with_fallback(thunk, Intent, query_type='x')\n"
+            "    return parsed.query_type + parsed.location\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+    def test_untracks_thunk_after_rebind(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    thunk = {'query_type': 'x'}\n"
+            "    return thunk['query_type']\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+    def test_multi_function_scope_isolation(self):
+        pipeline = self._HELPERS + (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def fn_a():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    parsed = _parse_instruct_result(thunk, Intent)\n"
+            "    return parsed.query_type\n"
+            "def fn_b(thunk):\n"
+            "    return thunk.query_type\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+    def test_walks_slots_and_constrained_slots(self):
+        bad = (
+            "from mellea import start_session\n"
+            "from .schemas import S\n"
+            "def f():\n"
+            "    with start_session('o','m') as m:\n"
+            "        t = m.instruct('go', format=S)\n"
+            "    return t.x\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {"slots.py": bad, "constrained_slots.py": bad},
+            )
+            result = lint_instruct_result_parse_before_access(pkg)
+            assert result.verdict == "fail"
+
+    def test_skips_unparseable_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp), {"pipeline.py": "def broken(:\n    pass\n"}
+            )
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+    def test_ignores_instruct_without_format_kwarg(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('classify the query')\n"
+            "    return thunk.value\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert (
+                lint_instruct_result_parse_before_access(pkg).verdict == "pass"
+            )
+
+
+# ─── TestFormatAnnotation ───
+
+
+class TestFormatAnnotation:
+    """Test cases for lint_format_annotation."""
+
+    def test_passes_with_format_and_model_validate_json(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    return Intent.model_validate_json(thunk.value)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert lint_format_annotation(pkg).verdict == "pass"
+
+    def test_passes_with_format_and_parse_instruct_result(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    return _parse_instruct_result(thunk, Intent)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert lint_format_annotation(pkg).verdict == "pass"
+
+    def test_passes_with_format_and_safe_parse_with_fallback(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go', format=Intent)\n"
+            "    return _safe_parse_with_fallback(thunk, Intent, query_type='x')\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert lint_format_annotation(pkg).verdict == "pass"
+
+    def test_fails_when_model_validate_json_with_no_format(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go')\n"
+            "    return Intent.model_validate_json(thunk.value)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_format_annotation(pkg)
+            assert result.verdict == "fail"
+            assert "thunk" in result.failures[0].message
+            assert "format=" in result.failures[0].message
+
+    def test_fails_when_parse_instruct_result_with_no_format(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go')\n"
+            "    return _parse_instruct_result(thunk, Intent)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_format_annotation(pkg)
+            assert result.verdict == "fail"
+            assert "_parse_instruct_result" in result.failures[0].message
+
+    def test_fails_when_safe_parse_with_fallback_with_no_format(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go')\n"
+            "    return _safe_parse_with_fallback(thunk, Intent, query_type='x')\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_format_annotation(pkg)
+            assert result.verdict == "fail"
+            assert "_safe_parse_with_fallback" in result.failures[0].message
+
+    def test_passes_when_thunk_unused_with_no_format(self):
+        """No-format instruct whose result is never parsed is not this lint's concern."""
+        pipeline = (
+            "from mellea import start_session\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('classify the query')\n"
+            "    return thunk\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert lint_format_annotation(pkg).verdict == "pass"
+
+    def test_dedups_multiple_parse_uses_of_same_thunk(self):
+        """A single bad instruct used twice for parsing emits one failure, not two."""
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import Intent\n"
+            "def run_pipeline():\n"
+            "    with start_session('o','m') as m:\n"
+            "        thunk = m.instruct('go')\n"
+            "    a = Intent.model_validate_json(thunk.value)\n"
+            "    b = _parse_instruct_result(thunk, Intent)\n"
+            "    return a, b\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_format_annotation(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 1
+
+    def test_walks_slots_and_constrained_slots(self):
+        bad = (
+            "from mellea import start_session\n"
+            "from .schemas import S\n"
+            "def f():\n"
+            "    with start_session('o','m') as m:\n"
+            "        t = m.instruct('go')\n"
+            "    return S.model_validate_json(t.value)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {"slots.py": bad, "constrained_slots.py": bad},
+            )
+            result = lint_format_annotation(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 2
+
+    def test_skips_unparseable_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp), {"pipeline.py": "def broken(:\n    pass\n"}
+            )
+            assert lint_format_annotation(pkg).verdict == "pass"
+
+    def test_passes_when_no_pipeline_files_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"main.py": "x = 1\n"})
+            result = lint_format_annotation(pkg)
+            assert result.verdict == "pass"
+            assert result.files_checked == 0
+
+
+# ─── TestSessionBoundary ───
+
+
+class TestSessionBoundary:
+    """Test cases for lint_session_boundary (KB5)."""
+
+    def test_passes_with_single_format_type(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import TriageVerdict\n"
+            "def run_pipeline(t: str) -> dict:\n"
+            "    with start_session('ollama', 'm') as m:\n"
+            "        v1 = m.instruct('Triage', format=TriageVerdict)\n"
+            "        v2 = m.instruct('Refine', format=TriageVerdict)\n"
+            "    return {}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert lint_session_boundary(pkg).verdict == "pass"
+
+    def test_fails_with_two_format_types_in_one_session(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import A, B\n"
+            "def run_pipeline(t: str) -> dict:\n"
+            "    with start_session('o','m') as m:\n"
+            "        x = m.instruct('one', format=A)\n"
+            "        y = m.instruct('two', format=B)\n"
+            "    return {}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_session_boundary(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 1
+            assert "A" in result.failures[0].message
+            assert "B" in result.failures[0].message
+
+    def test_passes_with_two_sessions_each_one_format(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import A, B\n"
+            "def f(x):\n"
+            "    with start_session('o','m') as m:\n"
+            "        a = m.instruct('1', format=A)\n"
+            "    with start_session('o','m') as m:\n"
+            "        b = m.instruct('2', format=B)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert lint_session_boundary(pkg).verdict == "pass"
+
+    def test_passes_with_no_format_kwarg(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "def run_pipeline(q):\n"
+            "    with start_session('o','m') as m:\n"
+            "        return m.instruct('Answer')\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            assert lint_session_boundary(pkg).verdict == "pass"
+
+    def test_fails_with_three_distinct_format_types(self):
+        pipeline = (
+            "from mellea import start_session\n"
+            "from .schemas import A, B, C\n"
+            "def f(x):\n"
+            "    with start_session('o','m') as m:\n"
+            "        a = m.instruct('1', format=A)\n"
+            "        b = m.instruct('2', format=B)\n"
+            "        c = m.instruct('3', format=C)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": pipeline})
+            result = lint_session_boundary(pkg)
             assert result.verdict == "fail"
             msg = result.failures[0].message
-            assert "req.validate" in msg
-            assert "ValueError" in msg
+            assert "A" in msg and "B" in msg and "C" in msg
+
+    def test_checks_slots_and_constrained_slots(self):
+        bad = (
+            "from mellea import start_session\n"
+            "from .schemas import A, B\n"
+            "def helper():\n"
+            "    with start_session('o','m') as m:\n"
+            "        m.instruct('x', format=A)\n"
+            "        m.instruct('y', format=B)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(
+                Path(tmp),
+                {"slots.py": bad, "constrained_slots.py": bad},
+            )
+            result = lint_session_boundary(pkg)
+            assert result.verdict == "fail"
+            assert len(result.failures) == 2
+
+    def test_skips_unparseable_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"pipeline.py": "def broken(:\n    pass\n"})
+            assert lint_session_boundary(pkg).verdict == "pass"
+
+    def test_passes_when_no_pipeline_files_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"main.py": "x = 1\n"})
+            result = lint_session_boundary(pkg)
+            assert result.verdict == "pass"
+            assert result.files_checked == 0
 
 
 # ─── TestFixturePydanticCoercion ───


### PR DESCRIPTION
## Summary

Adds three Step 7 structural lints that target the
m.instruct call-site / parse-site contract:

- **instruct-result-parse-before-access** — `m.instruct(format=Model)`
  returns a `ComputedModelOutputThunk`, not a Pydantic model. Direct
  field access on the thunk raises `AttributeError` at runtime. The
  lint requires the thunk to be parsed via `_parse_instruct_result`,
  `_safe_parse_with_fallback`, or `Model.model_validate_json(thunk.value)`
  before any attribute access.
- **format-annotation** — every `m.instruct(...)` call whose result is
  later parsed (via any of the three parsing patterns above) MUST
  carry a `format=` kwarg. Without it the LLM emits free-form text
  instead of constrained-decoded JSON; the Pydantic parse fails or
  silently produces a malformed object.
- **session-boundary** — each `start_session(...)` block must use at
  most one distinct `format=` type across its `m.instruct` calls.
  Mellea's schema priming locks the session to the first schema seen;
  subsequent `format=B` calls inside the same session keep producing
  A-shaped output. Fix is to split into separate `with
  start_session(...) as m:` blocks, one per schema.

All three are pure-AST checks over `pipeline.py`, `slots.py`, and
`constrained_slots.py`. No runtime introspection, no Mellea import,
no LLM cooperation needed.

## Why

These three failure modes share a common surface (the `m.instruct`
call site and its downstream parse) but each is hard to spot in
LLM-emitted code without dedicated structural detection:

- The thunk-vs-model confusion (KB1) is invisible at write-time:
  `thunk.field` looks like Pydantic field access, and compiles fine.
  It only fails at runtime, after a full LLM round-trip.
- A missing `format=` kwarg gives no static signal — the resulting
  string can parse-by-accident on lucky LLM output, then break
  silently on the next run when the LLM phrases the JSON differently.
- Mid-session schema switching (KB5) compiles, runs without error,
  and produces *wrong* output — the lint catches it before the
  package is shipped.

Each defect class has been observed in compiled skills; the lints
shift detection from runtime/empirical to Step 7 / pre-smoke.

## How

Three independent lints sharing three small helpers:

- `_is_m_instruct_call` — Attribute on Name `m`, attr `instruct`.
- `_instruct_call_has_format_kwarg` — keyword scan.
- `_iter_function_scopes` — module + every FunctionDef /
  AsyncFunctionDef, used by the per-function thunk-tracking pass.

**instruct-result-parse-before-access** maintains a per-scope set of
"raw thunk names" — variables bound by `var = m.instruct(...,
format=...)`. The walker records exempt nodes (thunk args consumed
by documented parsers, `thunk.value` inside `model_validate_json`),
then flags any other `<thunk>.attr` access. Thunks are dropped from
the set when consumed by a parser or rebound to a non-instruct value.

**format-annotation** indexes every `var = m.instruct(...)` Assign,
then walks the file for three parse patterns: `Model.model_validate_json(var.value)`,
`_parse_instruct_result(var, ...)`, and `_safe_parse_with_fallback(var, ...)`.
If any match fires on a thunk whose binding `m.instruct` lacks
`format=`, the lint fails on the original instruct call line.
Failures are deduped by `(file, line)` so one bad instruct used by
multiple parsers emits one finding.

**session-boundary** walks `with start_session(...) as m:` blocks
and collects the set of type names referenced via `format=` across
all `<x>.instruct(...)` calls inside the block. Two or more distinct
type names ⇒ failure. The message lists the names and prescribes
splitting the session.

## Files changed

- `src/mellea_skills_compiler/compile/lints.py` — three new lint
  functions, eight helpers (one shared section + per-lint helpers),
  added to `ALL_LINTS`. +527 lines.
- `tests/mellea_skills_compiler/compile/test_lints.py` — three new
  test classes:
  - `TestInstructResultParseBeforeAccess` (12 cases) — covers all
    three exempt patterns, direct field access, model_dump,
    parsed_repr, multi-function scope isolation, rebind-untracks,
    slots/constrained_slots coverage, unparseable-file skip,
    no-format-kwarg ignored.
  - `TestFormatAnnotation` (12 cases) — passes for all three parse
    patterns when format= is present, fails for each when missing,
    dedup of multiple parse uses, slots/constrained_slots coverage,
    unparseable skip, no-files passes-with-files_checked=0.
  - `TestSessionBoundary` (8 cases) — single format type passes,
    two/three format types fail with names in message, two
    sessions each-one-format pass, no-format-kwarg passes,
    slots/constrained_slots coverage, unparseable skip, no-files
    passes-with-files_checked=0.
  +477 lines.

## Test plan

- [x] `pytest tests/mellea_skills_compiler/compile/test_lints.py` —
      31 new cases, 70 total, all pass.
- [x] `python -c "from ...lints import run_lints; r =
      run_lints(<known-good-pkg>)"` — end-to-end runner returns 7
      lints in result, JSON report serialises cleanly.
- [x] Empirical no-regression check: ran the three new lints over 6
      already-compiled skill packages; zero false positives.
- [ ] Optional: re-compile a skill that historically hit the thunk-
      access defect; expect the lint to block at Step 7 instead of
      letting the bug reach smoke.