### PR TITLE
fix(config-writer): tolerate unknown category values; tighten schema to enum

### DIFF
--- a/.claude/melleafy/writers/config_writer.py
+++ b/.claude/melleafy/writers/config_writer.py
@@ -59,10 +59,21 @@ def render(emission: dict[str, Any] | str) -> str:
             groups[cat] = []
         groups[cat].append(constant)
 
-    # Emit C1..C9 in numeric order, ungrouped constants last.
+    # Emit C1..C9 in numeric order; unrecognised category values (anything
+    # outside the documented C1..C9 vocab) come next, sorted lexicographically;
+    # ungrouped constants (no category) come last. The schema constrains
+    # category to ^C[1-9]$ but the LLM has been observed emitting placeholders
+    # like '—' for "unclassified"; rather than crashing on int(c[1:]), the
+    # writer treats those as a soft-error and groups them under their own
+    # raw-value section header.
+    def _category_sort_key(c: str) -> tuple[int, int | str]:
+        if len(c) == 2 and c[0] == "C" and c[1].isdigit() and c[1] != "0":
+            return (0, int(c[1:]))
+        return (1, c)
+
     ordered_cats: list[str | None] = sorted(
         (k for k in groups if k is not None),
-        key=lambda c: int(c[1:]),  # type: ignore[index]
+        key=_category_sort_key,
     )
     if None in groups:
         ordered_cats.append(None)

--- a/.claude/schemas/config_emission.schema.json
+++ b/.claude/schemas/config_emission.schema.json
@@ -40,8 +40,8 @@
         },
         "category": {
           "type": "string",
-          "pattern": "^C[1-9]$",
-          "description": "Optional C-category code from the dependency plan (e.g. 'C1', 'C8'). Used by the writer to group constants under labelled section headers. Omit for runtime constants (LOOP_BUDGET etc.) that are not derived from a classified source element."
+          "enum": ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9"],
+          "description": "Optional C-category code from the dependency plan. Used by the writer to group constants under labelled section headers. Must be exactly one of 'C1'..'C9'. Omit the field entirely (do NOT use placeholder values like '-', 'N/A', or '—') for runtime constants (LOOP_BUDGET etc.) that are not derived from a classified source element."
         },
         "provenance": {
           "type": "object",

--- a/tests/mellea_skills_compiler/compile/test_config_writer.py
+++ b/tests/mellea_skills_compiler/compile/test_config_writer.py
@@ -1,0 +1,152 @@
+"""Unit tests for the deterministic config_writer.
+
+The writer renders config_emission.json into a Python source string. Tests
+exercise the category-grouping logic, the unknown-category tolerance path
+(added 2026-05-26 after a real LLM emitted category='—'), and the value
+representation choices.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_WRITER_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".claude"
+    / "melleafy"
+    / "writers"
+    / "config_writer.py"
+)
+
+
+def _load_writer():
+    """Load config_writer.py as a module (it lives outside src/ on purpose)."""
+    spec = importlib.util.spec_from_file_location("_config_writer", _WRITER_PATH)
+    assert spec and spec.loader, f"could not load {_WRITER_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestConfigWriterRender:
+    """Test cases for config_writer.render()."""
+
+    def test_renders_basic_constants_in_category_order(self):
+        writer = _load_writer()
+        emission = {
+            "constants": [
+                {"name": "B_VAL", "value": "second", "type": "str", "category": "C8"},
+                {"name": "A_VAL", "value": "first", "type": "str", "category": "C1"},
+            ]
+        }
+        source = writer.render(emission)
+        # C1 must appear before C8
+        assert source.index("A_VAL") < source.index("B_VAL")
+        # Section headers present
+        assert "# === C1:" in source
+        assert "# === C8:" in source
+
+    def test_renders_ungrouped_constants_last(self):
+        writer = _load_writer()
+        emission = {
+            "constants": [
+                {"name": "LOOP_BUDGET", "value": 4, "type": "int"},
+                {"name": "MODEL_ID", "value": "granite4.1:3b", "type": "str", "category": "C8"},
+            ]
+        }
+        source = writer.render(emission)
+        assert source.index("MODEL_ID") < source.index("LOOP_BUDGET")
+
+    def test_tolerates_unknown_category_value(self):
+        """LLM has been observed emitting placeholders like '—' for 'unclassified'.
+
+        Previously raised `invalid literal for int() with base 10: ''` because
+        the sort key called int(c[1:]) blindly. The writer should now treat
+        unknown categories as a soft fallback and group them under their own
+        raw-value section header without crashing.
+        """
+        writer = _load_writer()
+        emission = {
+            "constants": [
+                {"name": "MODEL_ID", "value": "x", "type": "str", "category": "C8"},
+                {"name": "PRIORITY_LEVELS", "value": "P1, P2, P3", "type": "str", "category": "—"},
+                {"name": "BACKEND", "value": "ollama", "type": "str", "category": "C8"},
+            ]
+        }
+        # Must not raise
+        source = writer.render(emission)
+        # All constants present
+        assert "MODEL_ID" in source
+        assert "BACKEND" in source
+        assert "PRIORITY_LEVELS" in source
+        # The unknown category gets a section header using its raw value
+        assert "# === —" in source
+        # Known C1..C9 categories sort before unknown ones
+        assert source.index("MODEL_ID") < source.index("PRIORITY_LEVELS")
+
+    def test_tolerates_arbitrary_string_category(self):
+        """Any string category that doesn't match C[1-9] should sort lex after C-codes."""
+        writer = _load_writer()
+        emission = {
+            "constants": [
+                {"name": "X", "value": "1", "type": "str", "category": "C2"},
+                {"name": "Y", "value": "2", "type": "str", "category": "misc"},
+                {"name": "Z", "value": "3", "type": "str", "category": "C1"},
+            ]
+        }
+        source = writer.render(emission)
+        # Order: C1 (Z), C2 (X), misc (Y)
+        assert source.index("Z: Final") < source.index("X: Final")
+        assert source.index("X: Final") < source.index("Y: Final")
+
+    def test_renders_provenance_comment(self):
+        writer = _load_writer()
+        emission = {
+            "constants": [
+                {
+                    "name": "FOO",
+                    "value": "bar",
+                    "type": "str",
+                    "category": "C1",
+                    "provenance": {"source_file": "SKILL.md", "source_lines": "10-12"},
+                },
+            ]
+        }
+        source = writer.render(emission)
+        assert "# PROVENANCE: SKILL.md:10-12" in source
+
+    def test_multiline_string_uses_triple_quotes(self):
+        writer = _load_writer()
+        emission = {
+            "constants": [
+                {
+                    "name": "PROMPT",
+                    "value": "line 1\nline 2",
+                    "type": "str",
+                    "category": "C1",
+                },
+            ]
+        }
+        source = writer.render(emission)
+        assert '"""line 1\nline 2"""' in source
+
+    def test_falls_back_to_repr_when_string_contains_triple_quotes(self):
+        writer = _load_writer()
+        emission = {
+            "constants": [
+                {
+                    "name": "DOCSTRING",
+                    "value": 'has """triple""" quotes\nand newline',
+                    "type": "str",
+                    "category": "C1",
+                },
+            ]
+        }
+        # Must not raise. The triple-quote path is avoided; repr() is used.
+        source = writer.render(emission)
+        assert "DOCSTRING" in source
+        assert "triple" in source


### PR DESCRIPTION
## Summary

Two-part fix for a `[writer:config.py] writer config_writer.py raised:
invalid literal for int() with base 10: ''` crash that prevented
config.py from being written and cascaded into a misleading
`parseable` lint failure (`ModuleNotFoundError: No module named
'<package>.config'`).

- **config_writer.py**: the category sort key called `int(c[1:])`
  unconditionally. Any category value outside the documented `C1..C9`
  vocab (e.g. an em-dash `'—'` placeholder for "unclassified") crashed
  the writer with the exact error above. Replaced with a stable
  two-tier sort key: known `C1..C9` categories sort numerically first;
  unknown categories sort lexicographically next; ungrouped (None)
  constants come last.
- **config_emission.schema.json**: replaced `pattern: "^C[1-9]$"` with
  `enum: ["C1", "C2", ..., "C9"]`. Semantically identical but more
  explicit — easier for the LLM to read off the schema, and the
  description now explicitly tells the LLM "do NOT use placeholder
  values like `-`, `N/A`, or `—`; omit the field instead."

## Why

The schema's `pattern` is documentation only — the wrapper does not
run `jsonschema` validation against the emission before invoking the
writer. The writer was the only guard. When the LLM emitted
`category: '—'` for a constant it considered "unclassified", the writer
crashed because `int('—'[1:])` = `int('')`.

The crash was logged as `[WARNING]` and the wrapper continued,
producing a package missing `config.py`. The `parseable` lint then
failed with a `ModuleNotFoundError` against the missing config module
— a misleading downstream symptom that pointed at `pipeline.py` rather
than the real wrapper-side cause.

The minimum-fix path was to make the writer tolerant so the immediate
crash class goes away. The schema is tightened in parallel so future
emissions get a clearer signal from the directive-rendered schema
(the LLM reads the schema as part of its emission instruction).

## How

**Writer sort key** (`config_writer.py:62-77`):

    def _category_sort_key(c: str) -> tuple[int, int | str]:
        if len(c) == 2 and c[0] == "C" and c[1].isdigit() and c[1] != "0":
            return (0, int(c[1:]))
        return (1, c)

Known `C1..C9` categories produce `(0, N)` and sort numerically. Any
other string produces `(1, value)` and sorts lexicographically after
the known group. `_CATEGORY_LABELS.get(cat, cat)` falls back to the
raw value for the section header so the output remains valid Python.

**Schema** (`config_emission.schema.json`): swapped `pattern` for
`enum` and added a "do not use placeholder values" sentence to the
description.

## Files changed

- `.claude/melleafy/writers/config_writer.py` — 8-line edit to the
  sort key. +12 lines (incl. comment).
- `.claude/schemas/config_emission.schema.json` — `pattern` →
  `enum`; description prose tightened. +1 / -1 lines.
- `tests/mellea_skills_compiler/compile/test_config_writer.py` —
  new file. 7 cases: basic category ordering, ungrouped-last,
  unknown-category tolerance (the regression case), arbitrary-string
  category, provenance comment, multi-line triple-quoting, triple-
  quote escape fallback. +152 lines.

## Test plan

- [x] `pytest tests/mellea_skills_compiler/compile/test_config_writer.py`
      — 7 new cases, all pass.
- [x] `pytest tests/` — 166 total, all pass (no regressions).
- [x] Hand-rendered the original failing
      `config_emission.json` (with `category: '—'`) through the patched
      writer; produced valid Python source without raising.
- [ ] Re-compile a real skill end-to-end after merge; confirm
      `[writer:config.py]` no longer logs `invalid literal for int()`
      warnings and that downstream `parseable` lint passes.