### PR TITLE
fix(lints): bundled-asset-path-resolution follows simple __file__ aliases

### DIFF
--- a/src/mellea_skills_compiler/compile/lints.py
+++ b/src/mellea_skills_compiler/compile/lints.py
@@ -174,6 +174,56 @@ def _is_skipped_path(rel_path: str) -> bool:
     return parts[0] in ("fixtures", "intermediate") or "__pycache__" in parts
 
 
+def _collect_file_root_aliases(tree: ast.AST) -> set[str]:
+    """Return Name identifiers in `tree` that are bound to a `__file__`-rooted
+    expression by a simple assignment.
+
+    Accepts a Name as a valid `__file__`-rooted alias if it appears anywhere in
+    `tree` as the target of an `Assign` or `AnnAssign` whose value satisfies
+    `_is_file_rooted` — i.e. `Path(__file__).parent`, the bare `__file__` Name,
+    or a `Call` taking `__file__` as an argument.
+
+    Example:
+      ```
+      pkg_dir = Path(__file__).parent       # pkg_dir → alias
+      references_dir = pkg_dir / "references"  # leftmost(pkg_dir) accepted
+      ```
+
+    The scan is file-wide (does not respect function scope). In machine-emitted
+    code, alias shadowing is rare; we trade exactness for a meaningful False-
+    positive reduction on the readable `<var> = Path(__file__).parent`
+    convention.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        targets: List[ast.expr] = []
+        value: Optional[ast.expr] = None
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+            value = node.value
+        if value is None or not _is_file_rooted(value):
+            continue
+        for tgt in targets:
+            if isinstance(tgt, ast.Name):
+                aliases.add(tgt.id)
+    return aliases
+
+
+def _leftmost_is_file_rooted(
+    leftmost: ast.AST, aliases: set[str]
+) -> bool:
+    """True if `leftmost` is a `__file__`-rooted expression OR a Name alias
+    bound to one earlier in the file."""
+    if _is_path_dunder_file_parent(leftmost):
+        return True
+    if isinstance(leftmost, ast.Name) and leftmost.id in aliases:
+        return True
+    return False
+
+
 def lint_bundled_asset_path_resolution(package_dir: Path) -> LintResult:
     """Reject any path-join construction that resolves a bundled-asset path
     via anything other than `Path(__file__).parent`."""
@@ -210,6 +260,8 @@ def lint_bundled_asset_path_resolution(package_dir: Path) -> LintResult:
         except SyntaxError:
             continue  # the parseable lint is responsible
 
+        aliases = _collect_file_root_aliases(tree)
+
         for node in ast.walk(tree):
             # Pattern 1: BinOp(Div) chain — Path(...) / "scripts/..."
             if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
@@ -223,7 +275,7 @@ def lint_bundled_asset_path_resolution(package_dir: Path) -> LintResult:
                             bundled_hit = d
                             first_str = r
                             break
-                if bundled_hit is None or _is_path_dunder_file_parent(leftmost):
+                if bundled_hit is None or _leftmost_is_file_rooted(leftmost, aliases):
                     continue
                 _record(
                     rel,
@@ -235,7 +287,9 @@ def lint_bundled_asset_path_resolution(package_dir: Path) -> LintResult:
                         f"`Path(__file__).parent / \"{bundled_hit}/<...>\"` "
                         f"(Rule OUT-6 in mellea-fy.md, Rule 2.5-2 in mellea-fy-deps.md). "
                         f"Common error: `Path(repo_root) / \"{bundled_hit}/...\"` — "
-                        f"must be `Path(__file__).parent / \"{bundled_hit}\" / ...`."
+                        f"must be `Path(__file__).parent / \"{bundled_hit}\" / ...`. "
+                        f"A local alias is fine: "
+                        f"`pkg_dir = Path(__file__).parent` then `pkg_dir / \"{bundled_hit}\"` passes."
                     ),
                 )
 
@@ -259,7 +313,11 @@ def lint_bundled_asset_path_resolution(package_dir: Path) -> LintResult:
                                 bundled_hit = d
                                 first_str = arg
                                 break
-                    if bundled_hit is None or _is_file_rooted(node.args[0]):
+                    base = node.args[0]
+                    base_is_file_rooted = _is_file_rooted(base) or (
+                        isinstance(base, ast.Name) and base.id in aliases
+                    )
+                    if bundled_hit is None or base_is_file_rooted:
                         continue
                     _record(
                         rel,

--- a/tests/mellea_skills_compiler/compile/test_lints.py
+++ b/tests/mellea_skills_compiler/compile/test_lints.py
@@ -298,6 +298,93 @@ class TestBundledAssetPathResolution:
                 f"{len(result.failures)}: {[f.message for f in result.failures]}"
             )
 
+    def test_passes_with_pkg_dir_alias_module_level(self):
+        """`pkg_dir = Path(__file__).parent; pkg_dir / 'references'` is a clean idiom."""
+        content = (
+            "from pathlib import Path\n"
+            "pkg_dir = Path(__file__).parent\n"
+            "references_dir = pkg_dir / 'references'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"loader.py": content})
+            result = lint_bundled_asset_path_resolution(pkg)
+            assert result.verdict == "pass", (
+                f"`pkg_dir = Path(__file__).parent` alias should make `pkg_dir / 'references'` "
+                f"pass; got failures: {[f.message for f in result.failures]}"
+            )
+
+    def test_passes_with_pkg_dir_alias_inside_function(self):
+        """Alias bound inside a function body must still be tracked."""
+        content = (
+            "from pathlib import Path\n"
+            "\n"
+            "def load_documents():\n"
+            "    pkg_dir = Path(__file__).parent\n"
+            "    references_dir = pkg_dir / 'references'\n"
+            "    return references_dir\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"loader.py": content})
+            result = lint_bundled_asset_path_resolution(pkg)
+            assert result.verdict == "pass", (
+                f"In-function alias should be tracked; got failures: "
+                f"{[f.message for f in result.failures]}"
+            )
+
+    def test_passes_with_annotated_alias(self):
+        """`pkg_dir: Path = Path(__file__).parent` AnnAssign form."""
+        content = (
+            "from pathlib import Path\n"
+            "pkg_dir: Path = Path(__file__).parent\n"
+            "p = pkg_dir / 'assets' / 'x.png'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"tools.py": content})
+            assert lint_bundled_asset_path_resolution(pkg).verdict == "pass"
+
+    def test_passes_with_alias_for_os_path_join(self):
+        """`pkg_dir = Path(__file__).parent; os.path.join(pkg_dir, 'scripts', ...)`."""
+        content = (
+            "import os\n"
+            "from pathlib import Path\n"
+            "pkg_dir = Path(__file__).parent\n"
+            "p = os.path.join(pkg_dir, 'scripts', 'go.sh')\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"tools.py": content})
+            assert lint_bundled_asset_path_resolution(pkg).verdict == "pass"
+
+    def test_fails_when_alias_bound_to_non_file_root(self):
+        """An alias to `os.getcwd()` or some other non-__file__ root should NOT be accepted."""
+        content = (
+            "import os\n"
+            "from pathlib import Path\n"
+            "pkg_dir = Path(os.getcwd())\n"
+            "p = pkg_dir / 'references' / 'doc.md'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"loader.py": content})
+            result = lint_bundled_asset_path_resolution(pkg)
+            assert result.verdict == "fail", (
+                f"Alias bound to a non-__file__ root must NOT be accepted; got "
+                f"verdict={result.verdict}"
+            )
+
+    def test_failure_message_mentions_alias_pattern(self):
+        """When the lint fails, the message hints that local aliases are accepted."""
+        content = (
+            "from pathlib import Path\n"
+            "p = Path('/tmp/whatever') / 'references' / 'x.md'\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = _make_package(Path(tmp), {"tools.py": content})
+            result = lint_bundled_asset_path_resolution(pkg)
+            assert result.verdict == "fail"
+            msg = result.failures[0].message
+            assert "pkg_dir" in msg and "alias" in msg.lower(), (
+                f"Failure message should mention the alias workaround; got: {msg}"
+            )
+
 
 # ─── TestRuntimeDefaultsBound ───
 


### PR DESCRIPTION
## Summary

LLM-emitted code that introduces a local alias for readability —

```python
pkg_dir = Path(__file__).parent
references_dir = pkg_dir / "references"
```

— was being flagged as a Rule OUT-6 violation. The lint only matched
the literal `Path(__file__).parent / "..."` shape and didn't follow
the single-step Name binding back one line. This produced a false
positive on a clean idiom an LLM produced unprompted.

## Why

Empirical trigger: compile of `lawveai-skills/politique-lanceur-
alerte-malik-taiar` emitted the alias pattern above in `loader.py`,
which the lint then rejected:

    loader.py:14 — Bundled asset path 'references' is resolved via
    'pkg_dir'. Bundled assets at <package_name>/references/ MUST be
    resolved via `Path(__file__).parent / "references/<...>"` ...

The expression IS semantically `Path(__file__).parent / "references"`
— just with a clearly-named intermediate variable. Penalising this
form pushes the LLM toward less readable code and creates churn.

Concretely this is the second observed-this-week failure mode where
the AST lint matched the canonical shape but not the LLM's
equivalent emission. We want lints that accept the patterns LLMs
actually produce, not just the patterns the directive's example
code uses.

## How

Adds a file-wide pre-scan (`_collect_file_root_aliases`) that walks
the AST for `Assign` / `AnnAssign` statements whose target is a Name
and whose value satisfies the existing `_is_file_rooted` check
(`__file__`, `Path(__file__).parent`, or a Call taking `__file__` as
an arg). Names found this way go into a per-file alias set.

The two existing patterns then accept the alias:

- **Pattern 1 (BinOp(Div) chain)** — `_leftmost_is_file_rooted` accepts
  either the literal `Path(__file__).parent` OR a Name whose id is in
  the alias set.
- **Pattern 2 (os.path.join base)** — equivalent check on the first
  positional arg.

Scope: file-level scan, not function-scoped. Alias shadowing across
functions is extremely rare in machine-emitted code; the gain of
accepting the readable convention outweighs the precision loss.

The failure message is also tweaked to hint that local aliases are
valid, so a future LLM emission can self-correct without a recompile:

    A local alias is fine: `pkg_dir = Path(__file__).parent` then
    `pkg_dir / "references"` passes.

## Files changed

- `src/mellea_skills_compiler/compile/lints.py` — new helpers
  `_collect_file_root_aliases` + `_leftmost_is_file_rooted`; the
  lint's two existing patterns now consult the alias set. +64
  lines.
- `tests/mellea_skills_compiler/compile/test_lints.py` — 6 new
  cases in `TestBundledAssetPathResolution`:
  - alias at module level
  - alias inside a function body
  - AnnAssign alias form (`pkg_dir: Path = Path(__file__).parent`)
  - alias used as os.path.join base
  - alias bound to a non-__file__ root (must still fail)
  - failure message hints at the alias pattern
  +87 lines.

## Test plan

- [x] `pytest tests/mellea_skills_compiler/compile/test_lints.py::
      TestBundledAssetPathResolution` — 15 total (9 existing + 6
      new), all pass.
- [x] `pytest tests/` — full suite 165/165 pass.
- [x] Empirical verification: ran the patched lint against
      `lawveai-skills/politique-lanceur-alerte-malik-taiar/.../
      loader.py` (the file that triggered the false positive); now
      passes cleanly.
