### PR TITLE
fix(smoke): prefer locally-defined run_pipeline as the entry point

### DIFF
--- a/src/mellea_skills_compiler/toolkit/file_utils.py
+++ b/src/mellea_skills_compiler/toolkit/file_utils.py
@@ -68,11 +68,28 @@ def load_skill_pipeline(pipeline_dir: Path):
         # Remove parent directory from sys.path
         sys.path.pop(0)
 
-    # Find the main entry point (run_* function).
-    # Prefer functions defined directly in pipeline.py over imported ones,
-    # since pipeline.py may import helper run_* functions from other modules
-    # (e.g., run_all_detectors from detectors.py) that aren't the entry point.
+    # Find the main entry point.
+    # Resolution order:
+    #   1. Locally-defined `run_pipeline` — the documented canonical entry
+    #      (`melleafy.json:entry_signature` always names this) and the only
+    #      name guaranteed to be the entry point regardless of any helper
+    #      `run_*` functions that may be defined alongside it.
+    #   2. Any other locally-defined `run_*` function — first match by
+    #      sorted dir() order.
+    #   3. Any imported `run_*` function (functions whose `__module__` is
+    #      not the pipeline module itself).
+    #
+    # The earlier "first locally-defined run_* wins" rule picked the
+    # alphabetically-first match, which silently bound `run_assessment_method`,
+    # `run_analysis`, etc. as the entry whenever the canonical `run_pipeline`
+    # sorted after a helper. The smoke-check would then call the helper with
+    # the fixture's kwargs and raise TypeError on signature mismatch.
     module_name = skill_pipeline.__name__
+
+    canonical = getattr(skill_pipeline, "run_pipeline", None)
+    if callable(canonical) and getattr(canonical, "__module__", None) == module_name:
+        return canonical
+
     run_fn = None
     imported_run_fn = None
     for attr_name in dir(skill_pipeline):

--- a/tests/mellea_skills_compiler/toolkit/test_file_utils.py
+++ b/tests/mellea_skills_compiler/toolkit/test_file_utils.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from mellea_skills_compiler.toolkit.file_utils import parse_spec_file
+from mellea_skills_compiler.toolkit.file_utils import (
+    load_skill_pipeline,
+    parse_spec_file,
+)
 
 
 class TestParseSkillMd:
@@ -217,3 +220,102 @@ Body content."""
                 parse_spec_file(path)
         finally:
             path.unlink()
+
+
+def _make_pipeline_package(root: Path, name: str, pipeline_source: str) -> Path:
+    """Materialise a synthetic <name>/pipeline.py package under `root`.
+
+    Returns the package directory (a child of `root` named `name`).
+    """
+    pkg_dir = root / name
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "pipeline.py").write_text(pipeline_source)
+    return pkg_dir
+
+
+class TestLoadSkillPipeline:
+    """Test cases for load_skill_pipeline — entry-point resolution.
+
+    Regression target: skills with helper `run_*` functions defined alongside
+    `run_pipeline` previously had the smoke check pick the alphabetically-
+    first match (e.g. `run_assessment_method` < `run_pipeline`), which
+    caused TypeError on the fixture's `user_input=...` kwargs because the
+    helper had a different signature.
+    """
+
+    def test_prefers_run_pipeline_over_alphabetically_earlier_helper(self):
+        """run_assessment_method sorts before run_pipeline; resolver must pick run_pipeline."""
+        source = (
+            "def run_assessment_method(org_context, refs):\n"
+            "    return ('helper', org_context, refs)\n"
+            "\n"
+            "def run_pipeline(user_input, doc=''):\n"
+            "    return ('canonical', user_input, doc)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_a_helper_pkg", source)
+            fn = load_skill_pipeline(pkg_dir)
+            # The canonical entry point takes user_input by kwarg and returns the canonical marker
+            assert fn.__name__ == "run_pipeline"
+            assert fn(user_input="hello") == ("canonical", "hello", "")
+
+    def test_falls_back_to_first_run_function_when_no_run_pipeline(self):
+        """If pipeline.py only defines run_other, that's the entry point."""
+        source = (
+            "def run_assessment_method(arg):\n"
+            "    return ('only-helper', arg)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_no_canonical_pkg", source)
+            fn = load_skill_pipeline(pkg_dir)
+            assert fn.__name__ == "run_assessment_method"
+
+    def test_prefers_run_pipeline_over_run_zzz_helper(self):
+        """run_zzz sorts after run_pipeline; verifies the fix isn't accidentally a sort-direction flip."""
+        source = (
+            "def run_pipeline(user_input):\n"
+            "    return ('canonical', user_input)\n"
+            "\n"
+            "def run_zzz_helper(x):\n"
+            "    return ('helper', x)\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_z_helper_pkg", source)
+            fn = load_skill_pipeline(pkg_dir)
+            assert fn.__name__ == "run_pipeline"
+
+    def test_prefers_local_run_pipeline_over_imported(self):
+        """An imported run_* (e.g. from a sibling module) must not shadow a locally-defined run_pipeline."""
+        source = (
+            "from .helpers import run_helper  # noqa: F401\n"
+            "\n"
+            "def run_pipeline(user_input):\n"
+            "    return ('canonical', user_input)\n"
+        )
+        helpers = "def run_helper(x):\n    return ('imported', x)\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_with_import_pkg", source)
+            (pkg_dir / "helpers.py").write_text(helpers)
+            fn = load_skill_pipeline(pkg_dir)
+            assert fn.__name__ == "run_pipeline"
+            assert fn.__module__.endswith("pipeline")
+
+    def test_raises_when_pipeline_module_missing(self):
+        """Missing pipeline.py raises with a helpful message."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_dir = Path(tmp) / "missing_pipeline_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "__init__.py").write_text("")
+            # No pipeline.py
+            with pytest.raises(Exception, match="pipeline.py"):
+                load_skill_pipeline(pkg_dir)
+
+    def test_raises_when_no_run_function_defined(self):
+        """A pipeline.py with no run_* function raises 'No run_* function found'."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg_dir = _make_pipeline_package(
+                Path(tmp), "synthetic_no_run_pkg", "x = 1\n"
+            )
+            with pytest.raises(Exception, match="No run_"):
+                load_skill_pipeline(pkg_dir)


### PR DESCRIPTION
## Summary

`toolkit/file_utils.py::load_skill_pipeline` picked the alphabetically-
first `run_*` function defined in `pipeline.py` because `dir()`
returns sorted names and the loop took the first locally-defined
match. Any skill with a helper function whose name sorted before
`pipeline` (e.g. `run_assessment_method`, `run_analysis`,
`run_check`) had the smoke check silently bind the helper as the
entry point. The fixture's canonical-shape kwargs then `TypeError`'d
against the helper's unrelated signature:

    TypeError: run_assessment_method() got an unexpected keyword
    argument 'user_input'

## Why

The resolver was emitting a fundamental contract mismatch: it
selected an entry point that *wasn't* the one declared in
`melleafy.json:entry_signature`, then handed the fixture (built
against the canonical entry) to the wrong callable. Smoke-check
failures showed up as kwarg/signature errors on internal helper
functions — the diagnostic surface was three layers removed from
the actual cause.

Empirical trigger: compile of `lawveai-skills/politique-lanceur-
alerte-malik-taiar/whistleblower_policy_malik_taiar_mellea`, whose
`pipeline.py` defined both `run_assessment_method` (line 134) and
`run_pipeline` (line 317). The resolver bound the helper. The Step 7
structural lints all passed; the smoke check then failed with the
TypeError above. The LLM emission was correct — the helper is a
legitimate internal function — but the wrapper's entry-point
resolution was wrong.

The risk surface is broad: any pipeline.py that follows the documented
pattern of "compose `run_pipeline` from named helper functions" hits
this if any helper sorts before `pipeline` (assessment, analysis,
check, classify — common verbs). Older skills happened to escape
because their helpers either sorted after `pipeline` (review, scan,
etc.) or used non-`run_` prefixes.

## How

Resolution order is now:

  1. **Locally-defined `run_pipeline`** — the documented canonical
     entry. `melleafy.json:entry_signature` always names it; if
     it's present in the module and defined locally (not imported),
     return immediately.
  2. **First locally-defined `run_*`** — existing fallback, by
     sorted `dir()` order. Covers skills that legitimately use a
     different entry name.
  3. **Imported `run_*`** — existing fallback for skills that
     re-export an entry from a sibling module.

Implementation is a 4-line `if canonical := getattr(...)`
short-circuit at the top of the existing loop. The rest of the
resolution logic is unchanged.

## Files changed

- `src/mellea_skills_compiler/toolkit/file_utils.py` — short-circuit
  on `run_pipeline` ahead of the existing loop; expanded the
  comment block to document the resolution order. +20 lines.
- `tests/mellea_skills_compiler/toolkit/test_file_utils.py` — new
  `TestLoadSkillPipeline` class with 6 cases:
  - prefers `run_pipeline` over alphabetically-earlier helper (the
    regression case)
  - falls back to first `run_*` when `run_pipeline` is absent
  - prefers `run_pipeline` over alphabetically-later helper (guards
    against accidental sort-direction inversion)
  - prefers local `run_pipeline` over imported `run_*`
  - raises when `pipeline.py` is missing
  - raises when no `run_*` is defined
  +104 lines.

## Test plan

- [x] `pytest tests/mellea_skills_compiler/toolkit/test_file_utils.py::
      TestLoadSkillPipeline` — 6 new cases, all pass.
- [x] `pytest tests/` — full suite 165/165 pass.
- [x] Empirical verification: ran `load_skill_pipeline` against the
      whistleblower package; resolver now returns
      `run_pipeline(user_input: str, ...)` instead of
      `run_assessment_method(org_context, refs)`.
- [ ] Re-run the whistleblower compile end-to-end to confirm the
      smoke check passes (or, if it fails, fails on a real LLM
      defect rather than wrapper misrouting).