### PR TITLE
fix(compile): resolve writers from installed compiler package, not generated skill dir

### DIFF
--- a/src/mellea_skills_compiler/compile/mellea_skills.py
+++ b/src/mellea_skills_compiler/compile/mellea_skills.py
@@ -40,6 +40,33 @@ LOGGER = configure_logger()
 console = Console(log_time=True)
 
 
+def _resolve_writers_repo_root(start: Path) -> Path:
+    """Walk up from ``start`` looking for a directory containing
+    ``.claude/melleafy/writers/``.
+
+    Used to locate the writers directory that the deterministic writer
+    renderer (``compile/writer_renderer.py``) reads. The caller passes in the
+    installed ``mellea_skills_compiler`` package directory (NOT the generated
+    skill package directory) so the walk-up succeeds even when the spec was
+    compiled out-of-tree.
+
+    Raises:
+        FileNotFoundError: if no ancestor directory contains
+            ``.claude/melleafy/writers/``. This indicates the compiler is
+            installed against a source tree that has been stripped of its
+            companion ``.claude/`` directory — the compile cannot proceed.
+    """
+    start = start.resolve()
+    for parent in [start, *start.parents]:
+        if (parent / ".claude" / "melleafy" / "writers").is_dir():
+            return parent
+    raise FileNotFoundError(
+        "Could not locate .claude/melleafy/writers/ relative to "
+        f"{start}. The compiler must be installed (editable or otherwise) "
+        "from a repo that contains .claude/melleafy/writers/."
+    )
+
+
 def _select_canonical_mellea_dir(skill_dir: Path, package_name: str) -> list[Path]:
     """Return the canonical *_mellea directory list under ``skill_dir``.
 
@@ -491,21 +518,26 @@ def compile(
             # the file the LLM put on disk. Logs WARN on diff so we can build
             # confidence the diffs are stable before flipping to ENFORCE mode.
             try:
+                import mellea_skills_compiler
                 from mellea_skills_compiler.compile.writer_renderer import (
                     default_writer_specs,
                     render_writers,
                 )
 
-                # Repo root = directory holding `.claude/`. Walk up from the
-                # package dir until we find it.
-                repo_root = mellea_dirs[0]
-                for parent in [repo_root, *repo_root.parents]:
-                    if (parent / ".claude" / "melleafy" / "writers").is_dir():
-                        repo_root = parent
-                        break
+                # Locate the writers directory by walking up from the
+                # *installed compiler package*, NOT from the generated
+                # package's directory. The previous walk-up-from-package
+                # logic only worked when the spec was compiled in-tree;
+                # out-of-tree skill specs (the standard eval-harness use
+                # case) silently fell off the top of the filesystem,
+                # defaulted repo_root to the package dir, and shipped
+                # packages missing config.py and fixtures/. See
+                # ``_resolve_writers_repo_root`` for the resolution helper.
+                _compiler_pkg_dir = Path(mellea_skills_compiler.__file__).resolve().parent
+                _writers_repo_root = _resolve_writers_repo_root(_compiler_pkg_dir)
                 render_writers(
                     mellea_dirs[0],
-                    default_writer_specs(repo_root),
+                    default_writer_specs(_writers_repo_root),
                     enforce=True,  # config.py promoted from WARN to ENFORCE in Step 3
                 )
             except Exception as renderer_exc:  # noqa: BLE001

--- a/tests/mellea_skills_compiler/compile/test_writer_renderer_path_resolution.py
+++ b/tests/mellea_skills_compiler/compile/test_writer_renderer_path_resolution.py
@@ -1,0 +1,141 @@
+"""Regression tests for `_resolve_writers_repo_root` in compile.mellea_skills.
+
+Background — the bug this pins:
+    The previous logic walked up from the *generated package directory* (e.g.
+    `<wherever>/my_skill_mellea/`) looking for `.claude/melleafy/writers/`.
+    For in-tree compiles this worked by accident because the generated
+    package sat inside the compiler repo. For out-of-tree compiles (the
+    standard eval-harness use case — spec lives in a separate skills repo)
+    the walk fell off the top of the filesystem without finding the writers,
+    `repo_root` defaulted to the package dir, `default_writer_specs` produced
+    paths like `<package>/.claude/melleafy/writers/config_writer.py` that
+    didn't exist, the writer subprocess failed with Errno 2, and the failure
+    was swallowed as a WARNING. The compiled package shipped without config.py
+    or fixtures/.
+
+    The fix walks up from the *installed compiler package* instead. This test
+    pins that behaviour and the explicit-FileNotFoundError on failure.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mellea_skills_compiler.compile.mellea_skills import _resolve_writers_repo_root
+
+
+class TestResolveWritersRepoRoot:
+    """Pin the writers-repo-root resolution semantics."""
+
+    def test_finds_writers_at_start_dir(self):
+        """If start dir itself contains .claude/melleafy/writers/, return it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".claude" / "melleafy" / "writers").mkdir(parents=True)
+            assert _resolve_writers_repo_root(root) == root.resolve()
+
+    def test_finds_writers_at_ancestor(self):
+        """Walks up until .claude/melleafy/writers/ is found."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".claude" / "melleafy" / "writers").mkdir(parents=True)
+            # Simulate the installed-package location: src/mellea_skills_compiler/compile/
+            deep = root / "src" / "mellea_skills_compiler" / "compile"
+            deep.mkdir(parents=True)
+            assert _resolve_writers_repo_root(deep) == root.resolve()
+
+    def test_raises_filenotfounderror_when_writers_absent(self, monkeypatch):
+        """No `.claude/melleafy/writers/` anywhere on the ancestor chain → hard error.
+
+        This is the case the previous walk-from-package logic silently swallowed,
+        producing incomplete packages that shipped with a falsely-green Step-7
+        verdict. The fix turns it into a loud FileNotFoundError.
+
+        We monkeypatch `Path.is_dir` so the walk-up cannot escape the tmp
+        subtree — otherwise the test would flake on systems where /tmp's
+        ancestors happen to contain the project's real `.claude/`.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp).resolve()
+            start = tmp_root / "a" / "b" / "c"
+            start.mkdir(parents=True)
+
+            real_is_dir = Path.is_dir
+
+            def constrained_is_dir(self):
+                try:
+                    resolved = self.resolve()
+                except OSError:
+                    return real_is_dir(self)
+                try:
+                    resolved.relative_to(tmp_root)
+                except ValueError:
+                    return False  # outside the sandbox → pretend absent
+                return real_is_dir(self)
+
+            monkeypatch.setattr(Path, "is_dir", constrained_is_dir)
+
+            with pytest.raises(FileNotFoundError) as exc_info:
+                _resolve_writers_repo_root(start)
+            msg = str(exc_info.value)
+            assert ".claude/melleafy/writers/" in msg, (
+                f"Error should name the missing directory; got: {msg}"
+            )
+
+    def test_does_not_walk_up_from_generated_package_dir(self, monkeypatch):
+        """Out-of-tree generated package — the OLD bug case.
+
+        Construct: generated package lives in an independent tmp tree with
+        no `.claude/` anywhere on its ancestor chain. The *correct* behaviour
+        is to NOT use this directory for resolution — the caller is supposed
+        to pass the installed compiler package dir. To pin this, we patch
+        `Path.is_dir` to refuse to acknowledge a `.claude/melleafy/writers/`
+        directory unless it sits under our synthetic 'compiler-install' root,
+        then confirm: resolving from the generated-package dir raises, and
+        resolving from the compiler-install dir succeeds.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp).resolve()
+            # Simulated compiler install with the writers
+            compiler_install = tmp_root / "compiler_repo"
+            (compiler_install / ".claude" / "melleafy" / "writers").mkdir(parents=True)
+            compiler_pkg_dir = compiler_install / "src" / "mellea_skills_compiler"
+            compiler_pkg_dir.mkdir(parents=True)
+
+            # Simulated out-of-tree skill spec / generated package
+            skill_repo = tmp_root / "skill_repo"
+            generated_pkg = skill_repo / "my_skill_mellea"
+            generated_pkg.mkdir(parents=True)
+
+            # Sanity: the compiler-install path resolves correctly.
+            assert _resolve_writers_repo_root(compiler_pkg_dir) == compiler_install.resolve()
+
+            # Patch the resolver so the walk-up from generated_pkg stops at
+            # tmp_root (i.e. it can't escape into the real filesystem where
+            # our actual .claude/melleafy/writers/ lives). We do this by
+            # monkeypatching the walk to constrain parents to tmp_root.
+            real_is_dir = Path.is_dir
+
+            def constrained_is_dir(self):
+                # Disallow matching anything outside tmp_root for this test.
+                try:
+                    resolved = self.resolve()
+                except OSError:
+                    return real_is_dir(self)
+                try:
+                    resolved.relative_to(tmp_root)
+                except ValueError:
+                    # Outside tmp_root → pretend it doesn't exist
+                    return False
+                return real_is_dir(self)
+
+            monkeypatch.setattr(Path, "is_dir", constrained_is_dir)
+
+            # Now: walking up from generated_pkg must NOT find the writers,
+            # because skill_repo has no .claude/ and we've blocked escape to
+            # the real filesystem.
+            with pytest.raises(FileNotFoundError):
+                _resolve_writers_repo_root(generated_pkg)


### PR DESCRIPTION
## Summary
- Adds `_resolve_writers_repo_root(start)` helper that walks up from a given dir to find `.claude/melleafy/writers/`, raising `FileNotFoundError` if absent
- Changes `compile.mellea_skills.compile()` to call the helper starting from `Path(mellea_skills_compiler.__file__).resolve().parent` (the installed compiler package) instead of the generated `*_mellea/` directory
- Adds `tests/mellea_skills_compiler/compile/test_writer_renderer_path_resolution.py` pinning the resolution semantics, including the out-of-tree regression case

## Background — the bug

The previous walk-up logic used the generated package directory as the start:

```python
repo_root = mellea_dirs[0]                       # generated *_mellea/ dir
for parent in [repo_root, *repo_root.parents]:
    if (parent / ".claude" / "melleafy" / "writers").is_dir():
        repo_root = parent
        break
```

For in-tree compiles this worked by accident because the generated package sat inside the compiler repo. For out-of-tree compiles the walk fell off the top of the filesystem without finding the writers, the loop fell through without updating `repo_root`, and `default_writer_specs(repo_root)` produced paths like `<generated_pkg>/.claude/melleafy/writers/config_writer.py` that don't exist.

The `render_writers()` call then raised, was caught by `except Exception as renderer_exc`, and was logged as a non-fatal WARN — the compile continued and reported success while shipping a package missing `config.py` and `fixtures/`.

Observed failure: `anthropic/doc-coauthoring` (61 minutes of LLM work), recovered only by relocating the skill into the compiler repo's working tree.

## Fix

Walk up from the *installed compiler package directory* instead. The compiler package is the canonical home for the writers — wherever the compiler is editable-installed from, `.claude/melleafy/writers/` is co-located. The new helper:

- Resolves the start path before walking (handles symlinks deterministically)
- Returns the first ancestor containing the writers
- Raises `FileNotFoundError` with an actionable message if none found

## Test plan
- [x] `pytest tests/mellea_skills_compiler/compile/test_writer_renderer_path_resolution.py -v` — 4/4 pass
  - `test_finds_writers_at_start_dir` — start dir itself has writers
  - `test_finds_writers_at_ancestor` — walk-up resolves correctly
  - `test_raises_filenotfounderror_when_writers_absent` — sandboxed monkeypatch confirms hard error semantics
  - `test_does_not_walk_up_from_generated_package_dir` — pins the regression: walking up from an out-of-tree generated package no longer succeeds by accident
- [x] `pytest tests/mellea_skills_compiler/compile/ -q` — 254/254 pass, no regressions
- [ ] CI to confirm the broader suite

