### PR TITLE
fix(compile): writer-renderer failures are hard errors

### DIFF
--- a/src/mellea_skills_compiler/compile/mellea_skills.py
+++ b/src/mellea_skills_compiler/compile/mellea_skills.py
@@ -512,39 +512,30 @@ def compile(
         skill_dir = spec_path if spec_path.is_dir() else spec_path.parent
         mellea_dirs = _select_canonical_mellea_dir(skill_dir, package_name)
         if mellea_dirs:
-            # Wrapper-side writer invocation (migration phase: WARN only).
-            # Reads intermediate/<artifact>_emission.json, runs the deterministic
-            # writer in .claude/melleafy/writers/, and diffs the output against
-            # the file the LLM put on disk. Logs WARN on diff so we can build
-            # confidence the diffs are stable before flipping to ENFORCE mode.
-            try:
-                import mellea_skills_compiler
-                from mellea_skills_compiler.compile.writer_renderer import (
-                    default_writer_specs,
-                    render_writers,
-                )
+            # Wrapper-side writer invocation.
+            # Reads intermediate/<artifact>_emission.json and runs the
+            # deterministic writer in .claude/melleafy/writers/. config.py
+            # and fixtures/ are mandatory artifacts — any failure here is a
+            # hard error: the compiled package would otherwise ship without
+            # them while lints pass against the LLM-emitted files, producing
+            # a falsely-green compile.
+            import mellea_skills_compiler
+            from mellea_skills_compiler.compile.writer_renderer import (
+                default_writer_specs,
+                render_writers,
+            )
 
-                # Locate the writers directory by walking up from the
-                # *installed compiler package*, NOT from the generated
-                # package's directory. The previous walk-up-from-package
-                # logic only worked when the spec was compiled in-tree;
-                # out-of-tree skill specs (the standard eval-harness use
-                # case) silently fell off the top of the filesystem,
-                # defaulted repo_root to the package dir, and shipped
-                # packages missing config.py and fixtures/. See
-                # ``_resolve_writers_repo_root`` for the resolution helper.
-                _compiler_pkg_dir = Path(mellea_skills_compiler.__file__).resolve().parent
-                _writers_repo_root = _resolve_writers_repo_root(_compiler_pkg_dir)
-                render_writers(
-                    mellea_dirs[0],
-                    default_writer_specs(_writers_repo_root),
-                    enforce=True,  # config.py promoted from WARN to ENFORCE in Step 3
-                )
-            except Exception as renderer_exc:  # noqa: BLE001
-                LOGGER.warning(
-                    "Writer renderer failed (non-fatal during migration): %s",
-                    renderer_exc,
-                )
+            # Locate the writers directory by walking up from the
+            # *installed compiler package*, NOT from the generated
+            # package's directory. See `_resolve_writers_repo_root` for
+            # the resolution helper.
+            _compiler_pkg_dir = Path(mellea_skills_compiler.__file__).resolve().parent
+            _writers_repo_root = _resolve_writers_repo_root(_compiler_pkg_dir)
+            render_writers(
+                mellea_dirs[0],
+                default_writer_specs(_writers_repo_root),
+                enforce=True,
+            )
 
             # validate compiled skill pipeline
             validate(mellea_dirs[0], no_run=no_run, all_fixtures=False)


### PR DESCRIPTION
## Summary
- Removes the `try / except Exception as renderer_exc` block wrapping the writer-renderer invocation in `compile.mellea_skills.compile()`
- Any failure in writer rendering — schema validation, missing writers directory, schema-vs-emission mismatch, subprocess error — now propagates instead of being logged as a non-fatal WARN
- Updates the surrounding comment block to declare hard-error intent

**Depends on #24** (`fix(compile): resolve writers from installed compiler package`). Branch is based off that PR's branch. When #24 merges, this PR can be rebased onto `main`.

## Why

#24 fixed the writer-root resolution but explicitly left the surrounding try/except in place — that PR's diff was a pure correctness improvement for the success path. This PR is the deliberate behaviour change for the failure path.

The swallow was the reason `anthropic/doc-coauthoring` took 61 minutes of LLM work to fail visibly: when `render_writers()` raised because the walk-up returned a wrong `repo_root`, the exception was caught and logged. The compile continued to the lint phase, lints ran clean against the LLM-emitted artifacts (which existed on disk), the compile reported PASS, and the package shipped without `config.py` or `fixtures/`. The defect was invisible to operators looking at the green wrapper output.

In general the wrapper's writer phase emits **mandatory artifacts**:
- `config.py` (runtime defaults, prompt fragments, scope rules)
- `fixtures/` (smoke-check inputs)

A compile missing these is structurally broken even when the LLM-emitted files lint clean. Continuing past a writer-renderer failure is exactly the wrong default.

## What changes for users

- **Before**: writer-renderer error → `LOGGER.warning("Writer renderer failed (non-fatal during migration): ...")` → compile continues → final verdict reflects only the post-writer steps.
- **After**: writer-renderer error → exception propagates out of `compile()` → the surrounding error handler (in the CLI / driver) handles it like any other compile failure, with the original traceback intact.

There is no change for compiles where the writer renderer succeeds.

## Test plan
- [x] `pytest tests/mellea_skills_compiler/compile/ -q` — 254/254 pass, no regressions
- [x] `test_raises_filenotfounderror_when_writers_absent` (added in #24) confirms the helper's hard-error contract; with this PR the FileNotFoundError now propagates from `compile()` as well
- [ ] CI to confirm the broader suite
- **No new test added in this PR.** A behavioural test for "exception propagates from `compile()`" would require mocking enough of the LLM-orchestration scaffolding to reach the writer step, which is a significant test-fixture investment for a one-line behaviour change. The PR 1 helper test plus the visible code change provide adequate evidence; happy to add an integration test if reviewers prefer.
