### PR TITLE
Companion directory changes

### DIFF
--- a/src/mellea_skills_compiler/compile/__init__.py
+++ b/src/mellea_skills_compiler/compile/__init__.py
@@ -1,4 +1,0 @@
-from pathlib import Path
-
-
-CLAUDE_DIR = Path(__file__).parent.absolute() / "claude"

--- a/src/mellea_skills_compiler/compile/claude_directives.py
+++ b/src/mellea_skills_compiler/compile/claude_directives.py
@@ -134,7 +134,7 @@ def build_system_prompt(
 
     ``package_name`` is the wrapper-derived Rule OUT-2 name (e.g.
     ``weather_mellea``) substituted into the prompt body so the LLM uses the
-    same name the wrapper computes for ``mirror_companion_dirs`` and the
+    same name the wrapper computes for ``mirror_dir_contents_to_target`` and the
     post-session ``*_mellea`` discovery. Previously the prompt carried the
     literal placeholder ``<package_name>`` and the LLM re-derived the name
     from the frontmatter — a long/complex name (e.g.

--- a/src/mellea_skills_compiler/compile/claude_directives.py
+++ b/src/mellea_skills_compiler/compile/claude_directives.py
@@ -1,5 +1,4 @@
 import json
-import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -7,48 +6,6 @@ from mellea_skills_compiler.toolkit.logging import configure_logger
 
 
 LOGGER = configure_logger()
-
-# Rule OUT-2 — package name derivation; Rule OUT-6 — companion-directory mirror.
-# Kept here so the pre-mellea-fy mirror step can resolve the destination
-# without invoking the slash command.
-_COMPANION_DIRS = ("scripts", "references", "assets")
-
-
-def derive_package_name(spec_path: Path, frontmatter: dict | None) -> str:
-    """Apply Rule OUT-2 (lowercase, hyphens/spaces → underscores, append `_mellea`).
-
-    For .md sources, prefer the frontmatter `name:` field; fall back to the
-    parent directory name. For directory inputs (multi-file runtimes), use
-    the directory name.
-    """
-    if spec_path.is_dir():
-        raw = spec_path.name
-    else:
-        raw = (frontmatter or {}).get("name") or spec_path.parent.name
-    name = str(raw).lower().replace("-", "_").replace(" ", "_")
-    while "__" in name:
-        name = name.replace("__", "_")
-    name = name.strip("_") or "skill"
-    return f"{name}_mellea"
-
-
-def mirror_companion_dirs(skill_dir: Path, package_dir: Path) -> list[str]:
-    """Rule OUT-6 — mirror companion directories from skill root into the package.
-
-    Runs deterministically before mellea-fy so the LLM sees the mirrored
-    assets in <package_name>/ when it generates code, reinforcing the
-    package-relative path-resolution invariant. Returns the list of
-    directory names actually mirrored (for logging).
-    """
-    package_dir.mkdir(parents=True, exist_ok=True)
-    mirrored: list[str] = []
-    for asset_dir in _COMPANION_DIRS:
-        src = skill_dir / asset_dir
-        if src.is_dir():
-            dst = package_dir / asset_dir
-            shutil.copytree(src, dst, dirs_exist_ok=True)
-            mirrored.append(asset_dir)
-    return mirrored
 
 
 # Defaults for the LLM backend and model that compiled skills use at runtime.

--- a/src/mellea_skills_compiler/compile/mellea_skills.py
+++ b/src/mellea_skills_compiler/compile/mellea_skills.py
@@ -242,16 +242,20 @@ def compile(
     spec_dir = spec_path if spec_path.is_dir() else spec_path.parent
     spec_md_path = _get_spec_md_path(spec_path)
     try:
-        spec_frontmatter = parse_spec_file(spec_md_path).get("frontmatter")
-        if spec_frontmatter:
-            rprint(
-                Panel(
-                    json.dumps(spec_frontmatter, indent=2),
-                    title="Specification",
-                    subtitle=str(spec_path),
-                )
-            )
+        if spec_md_path:
+            spec_frontmatter = parse_spec_file(spec_md_path).get("frontmatter")
     except Exception as e:
+        LOGGER.warning(f"Failed to parse spec file {spec_md_path}: {e}")
+
+    if spec_frontmatter:
+        rprint(
+            Panel(
+                json.dumps(spec_frontmatter, indent=2),
+                title="Specification",
+                subtitle=str(spec_path),
+            )
+        )
+    else:
         rprint(
             Panel(
                 f"Name: {spec_path.name.replace("_"," ").title()}\nPath: {str(spec_path)}",

--- a/src/mellea_skills_compiler/compile/mellea_skills.py
+++ b/src/mellea_skills_compiler/compile/mellea_skills.py
@@ -16,8 +16,6 @@ from rich.panel import Panel
 
 from mellea_skills_compiler.compile.claude_directives import (
     build_system_prompt,
-    derive_package_name,
-    mirror_companion_dirs,
     resolve_runtime_defaults,
     write_compile_settings,
     write_runtime_directive,
@@ -34,18 +32,23 @@ from mellea_skills_compiler.enums import (
     InferenceModel,
     SpecFileFormat,
 )
-from mellea_skills_compiler.toolkit.file_utils import parse_spec_file
+from mellea_skills_compiler.toolkit.file_utils import (
+    mirror_dir_contents_to_target,
+    parse_spec_file,
+)
 from mellea_skills_compiler.toolkit.logging import configure_logger
 
 
 LOGGER = configure_logger()
 console = Console(log_time=True)
 
+IGNORE_COMPANION_DIRS_ITEMS = ["audit", "pyproject.toml"]
 
-def _select_canonical_mellea_dir(spec_path: Path, package_name: str) -> Path:
-    """Return the canonical *_mellea directory list under ``skill_dir``.
 
-    Filters ``skill_dir`` for entries ending in ``_mellea`` and resolves which
+def _select_canonical_mellea_dir(spec_dir: Path, package_name: str) -> Path:
+    """Return the canonical *_mellea directory list under ``spec_dir``.
+
+    Filters ``spec_dir`` for entries ending in ``_mellea`` and resolves which
     one is the wrapper-canonical compiled package per the wrapper-derived
     ``package_name``. The LLM is now told the package name verbatim via
     ``build_system_prompt`` (see ``compile/claude_directives.py``), so under
@@ -64,10 +67,8 @@ def _select_canonical_mellea_dir(spec_path: Path, package_name: str) -> Path:
             re-running is required.
     """
 
-    skill_dir = spec_path if spec_path.is_dir() else spec_path.parent
-
     mellea_dirs = [
-        d for d in skill_dir.iterdir() if d.is_dir() and d.name.endswith("_mellea")
+        d for d in spec_dir.iterdir() if d.is_dir() and d.name.endswith("_mellea")
     ]
     if len(mellea_dirs) > 1:
         canonical = [d for d in mellea_dirs if d.name == package_name]
@@ -80,14 +81,14 @@ def _select_canonical_mellea_dir(spec_path: Path, package_name: str) -> Path:
                 "frontmatter names (Rule OUT-2). Clean them up after "
                 "the compile completes.",
                 len(mellea_dirs),
-                skill_dir,
+                spec_dir,
                 canonical[0].name,
                 [d.name for d in stray],
             )
             return canonical[0]
         raise Exception(
             f"Found {len(mellea_dirs)} *_mellea directories in "
-            f"{skill_dir}, none matching the wrapper-derived "
+            f"{spec_dir}, none matching the wrapper-derived "
             f"package name {package_name!r}: "
             f"{[d.name for d in mellea_dirs]}. Remove stray "
             f"directories and re-run."
@@ -105,12 +106,12 @@ def _select_canonical_mellea_dir(spec_path: Path, package_name: str) -> Path:
         )
 
     if not mellea_dirs:
-        raise Exception(f"No *_mellea directory found in {skill_dir} after compilation")
+        raise Exception(f"No *_mellea directory found in {spec_dir} after compilation")
 
     return mellea_dirs[0]
 
 
-def _get_spec_md_path(spec_path: Path):
+def _get_spec_md_path(spec_path: Path) -> Optional[Path]:
     spec_file_path = None
     if spec_path.is_dir():
         if (spec_path / SpecFileFormat.SKILL_FILE_MD).exists():
@@ -121,6 +122,24 @@ def _get_spec_md_path(spec_path: Path):
         spec_file_path = spec_path
 
     return spec_file_path
+
+
+def _derive_mellea_package_name(spec_path: Path, frontmatter: dict | None) -> str:
+    """Apply Rule OUT-2 (lowercase, hyphens/spaces → underscores, append `_mellea`).
+
+    For .md sources, prefer the frontmatter `name:` field; fall back to the
+    parent directory name. For directory inputs (multi-file runtimes), use
+    the directory name.
+    """
+    if spec_path.is_dir():
+        raw = spec_path.name
+    else:
+        raw = (frontmatter or {}).get("name") or spec_path.parent.name
+    name = str(raw).lower().replace("-", "_").replace(" ", "_")
+    while "__" in name:
+        name = name.replace("__", "_")
+    name = name.strip("_") or "skill"
+    return f"{name}_mellea"
 
 
 def validate(package_dir: Path, *, no_run: bool, all_fixtures: bool) -> None:
@@ -218,24 +237,25 @@ def compile(
             f"The skill specification file or directory cannot be found: {spec_path}"
         )
 
+    # Derive and create spec related fields
+    spec_dir = spec_path if spec_path.is_dir() else spec_path.parent
+    spec_md_path = _get_spec_md_path(spec_path)
+    try:
+        spec_frontmatter = parse_spec_file(spec_md_path).get("frontmatter")
+    except Exception as e:
+        LOGGER.warning(f"Failed to parse spec file {spec_md_path}: {e}")
+
     # print specs frontmatter if available
-    if spec_md_path := _get_spec_md_path(spec_path):
-        try:
-            specs = parse_spec_file(spec_md_path)
-            rprint(
-                Panel(
-                    json.dumps(
-                        specs.get("frontmatter", {"Name", spec_path.name}),
-                        indent=2,
-                    ),
-                    title="Specification",
-                    subtitle=str(spec_path),
-                )
-            )
-        except Exception:
-            console.print(f"Spec Path: " + str(spec_path))
-    else:
-        console.print(f"Spec Path: " + str(spec_path))
+    rprint(
+        Panel(
+            json.dumps(
+                spec_frontmatter or {"Name": spec_path.name},
+                indent=2,
+            ),
+            title="Specification",
+            subtitle=str(spec_path),
+        )
+    )
 
     # Check and verify claude model
     available_models = [model.id for model in Anthropic().models.list()]
@@ -294,34 +314,29 @@ def compile(
         "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{proxy_port}",
     }
 
+    # Derive mellea package name from the spec frontmatter
+    mellea_package_name = _derive_mellea_package_name(spec_path, spec_frontmatter)
+    mellea_package_dir = spec_dir / mellea_package_name
+
     # Rule OUT-6 — mirror companion directories from skill root into the
     # package directory BEFORE invoking mellea-fy. This is deterministic
     # plumbing (not the LLM's job) so the mirror cannot be skipped or
     # mis-applied. The LLM then generates code in a package directory that
     # already contains its bundled scripts/references/assets, reinforcing
     # the Path(__file__).parent path-resolution invariant.
-    skill_dir = spec_path if spec_path.is_dir() else spec_path.parent
-    _frontmatter: dict | None = None
-    if not spec_path.is_dir() and spec_path.suffix == ".md":
-        try:
-            _frontmatter = parse_spec_file(spec_path).get("frontmatter")
-        except Exception:
-            _frontmatter = None
-    package_name = derive_package_name(spec_path, _frontmatter)
-    package_dir = skill_dir / package_name
     try:
-        mirrored = mirror_companion_dirs(skill_dir, package_dir)
+        mirrored = mirror_dir_contents_to_target(
+            spec_dir,
+            mellea_package_dir,
+            ignore_patterns=IGNORE_COMPANION_DIRS_ITEMS + [mellea_package_name],
+        )
         if mirrored:
             LOGGER.info(
-                "Mirrored companion dirs into %s/: %s (Rule OUT-6)",
-                package_name,
-                ", ".join(mirrored),
+                f"Mirrored {len(mirrored)} item(s) into {mellea_package_name}/: {', '.join(mirrored)} (Rule OUT-6)"
             )
     except Exception as mirror_exc:
         LOGGER.warning(
-            "Companion-directory mirror failed for %s: %s. mellea-fy will continue.",
-            package_dir,
-            mirror_exc,
+            f"Companion-directory mirror failed for {mellea_package_dir}: {mirror_exc}. mellea-fy will continue."
         )
 
     # Pre-populate the deterministic grounding artifacts (Steps 2.5e and 2.5f
@@ -330,7 +345,7 @@ def compile(
     # docs.mellea.ai itself. We write `mellea_api_ref.json` and
     # `mellea_doc_index.json` here; the slash command's responsibility shrinks
     # to verifying the files exist and consuming them.
-    intermediate_dir = package_dir / "intermediate"
+    intermediate_dir = mellea_package_dir / "intermediate"
     try:
         write_mellea_api_ref(intermediate_dir, refresh=refresh_cache)
         write_mellea_doc_index(intermediate_dir, refresh=refresh_cache)
@@ -361,16 +376,15 @@ def compile(
             "the post-compile lint will skip its runtime-defaults check.",
             exc,
         )
-    system_prompt = build_system_prompt(
-        chosen_backend, chosen_model_id, defaults_source, package_name
-    )
 
     # Write the per-invocation Claude Code settings file with deny rules for
     # the paths the wrapper renders authoritatively (currently config.py).
     # Passed to claude via --settings; deny rules are honoured deterministically
     # in -p mode (verified in the synthetic test).
     try:
-        compile_settings_path = write_compile_settings(intermediate_dir, package_dir)
+        compile_settings_path = write_compile_settings(
+            intermediate_dir, mellea_package_dir
+        )
     except Exception as exc:
         LOGGER.warning(
             "Could not write per-invocation settings (%s). Falling back to no "
@@ -378,6 +392,11 @@ def compile(
             exc,
         )
         compile_settings_path = None
+
+    # Build claude system prompt
+    system_prompt = build_system_prompt(
+        chosen_backend, chosen_model_id, defaults_source, mellea_package_name
+    )
 
     # Start compilation process
     process = None
@@ -479,7 +498,7 @@ def compile(
             )
 
         # Get the melleafy compiled directory
-        mellea_dir: Path = _select_canonical_mellea_dir(spec_path, package_name)
+        mellea_dir: Path = _select_canonical_mellea_dir(spec_dir, mellea_package_name)
         if mellea_dir.exists():
             # Render respective artefact writers
             render_writers(mellea_dir, enforce=True)

--- a/src/mellea_skills_compiler/compile/mellea_skills.py
+++ b/src/mellea_skills_compiler/compile/mellea_skills.py
@@ -6,7 +6,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 from urllib.parse import urlparse
 
 from anthropic import Anthropic
@@ -124,7 +124,7 @@ def _get_spec_md_path(spec_path: Path) -> Optional[Path]:
     return spec_file_path
 
 
-def _derive_mellea_package_name(spec_path: Path, frontmatter: dict | None) -> str:
+def _derive_mellea_package_name(spec_path: Path, frontmatter: Optional[Dict]) -> str:
     """Apply Rule OUT-2 (lowercase, hyphens/spaces → underscores, append `_mellea`).
 
     For .md sources, prefer the frontmatter `name:` field; fall back to the
@@ -237,28 +237,35 @@ def compile(
             f"The skill specification file or directory cannot be found: {spec_path}"
         )
 
-    # Derive and create spec related fields
+    # Get spec related fields
+    spec_frontmatter: Optional[Dict] = None
     spec_dir = spec_path if spec_path.is_dir() else spec_path.parent
     spec_md_path = _get_spec_md_path(spec_path)
     try:
         spec_frontmatter = parse_spec_file(spec_md_path).get("frontmatter")
+        if spec_frontmatter:
+            rprint(
+                Panel(
+                    json.dumps(spec_frontmatter, indent=2),
+                    title="Specification",
+                    subtitle=str(spec_path),
+                )
+            )
     except Exception as e:
-        LOGGER.warning(f"Failed to parse spec file {spec_md_path}: {e}")
-
-    # print specs frontmatter if available
-    rprint(
-        Panel(
-            json.dumps(
-                spec_frontmatter or {"Name": spec_path.name},
-                indent=2,
-            ),
-            title="Specification",
-            subtitle=str(spec_path),
+        rprint(
+            Panel(
+                f"Name: {spec_path.name.replace("_"," ").title()}\nPath: {str(spec_path)}",
+                title="Specification",
+            )
         )
-    )
 
     # Check and verify claude model
-    available_models = [model.id for model in Anthropic().models.list()]
+    available_models = None
+    try:
+        available_models = [model.id for model in Anthropic().models.list()]
+    except Exception as e:
+        raise Exception(f"Unable to connect to Anthropic API - {str(e)}")
+
     if not available_models:
         raise ValueError(f"No claude models available with your API key.")
 

--- a/src/mellea_skills_compiler/toolkit/file_utils.py
+++ b/src/mellea_skills_compiler/toolkit/file_utils.py
@@ -1,8 +1,9 @@
 import importlib
 import re
+import shutil
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import yaml
 from rich.console import Console
@@ -167,3 +168,67 @@ def load_fixtures(pipeline_dir: Path) -> List[Dict]:
         raise Exception(f"No valid FIXTURES found in {fixtures_dir}")
     else:
         return fixtures
+
+
+def mirror_dir_contents_to_target(
+    source_dir: Path,
+    target_dir: Path,
+    include_only: Optional[List[str]] = None,
+    ignore_patterns: Optional[List[str]] = None,
+) -> List[str]:
+    """Mirror directory contents from source to target directory.
+
+    Copies all files and subdirectories from source_dir into target_dir,
+    excluding items in the ignore list. If `include_only` provided, copy only those items.
+    Skips copying if the target directory is inside the source to prevent infinite recursion.
+
+    Args:
+        source_dir Path: Source directory to copy from
+        target_dir Path: Destination directory (created if it doesn't exist)
+        include_only List[str], optional: Include items in the given list only. Default is None.
+        ignore_patterns List[str], optional: List of file/directory names to skip. Default is None.
+
+    Returns:
+        List of item names that were successfully copied
+
+    Raises:
+        OSError: If file operations fail
+
+    Example:
+        >>> mirror_dir_contents_to_target(
+        ...     Path("/skill"),
+        ...     Path("/skill/skill_mellea"),
+        ...     ignore_patterns=["audit", "pyproject.toml"]
+        ... )
+        ['scripts', 'references', 'spec.md']
+    """
+
+    mirrored: List[str] = []
+
+    # Ensure target directory exists
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    for source in source_dir.iterdir():
+        # If include_only provided, skip items NOT in it
+        if include_only and source.name not in include_only:
+            continue
+
+        # Skip items in ignore_patterns
+        if ignore_patterns and source.name in ignore_patterns:
+            continue
+
+        # Skip recursion
+        if source == target_dir or source.is_relative_to(target_dir):
+            continue
+
+        target = target_dir / source.name
+        try:
+            if source.is_dir():
+                shutil.copytree(source, target, dirs_exist_ok=True)
+            else:
+                shutil.copy(source, target)
+            mirrored.append(source.name)
+        except Exception as e:
+            LOGGER.warning(f"Failed to mirror {source.name}: {e}")
+
+    return mirrored

--- a/src/mellea_skills_compiler/toolkit/file_utils.py
+++ b/src/mellea_skills_compiler/toolkit/file_utils.py
@@ -226,7 +226,7 @@ def mirror_dir_contents_to_target(
             if source.is_dir():
                 shutil.copytree(source, target, dirs_exist_ok=True)
             else:
-                shutil.copy(source, target)
+                shutil.copy2(source, target)
             mirrored.append(source.name)
         except Exception as e:
             LOGGER.warning(f"Failed to mirror {source.name}: {e}")

--- a/tests/mellea_skills_compiler/compile/test_mellea_skills_helpers.py
+++ b/tests/mellea_skills_compiler/compile/test_mellea_skills_helpers.py
@@ -1,8 +1,8 @@
 """Unit tests for the deterministic pre-mellea-fy helpers in
 mellea_skills_compiler.compile.mellea_skills.
 
-These cover the small private helpers (`derive_package_name`,
-`mirror_companion_dirs`, `resolve_runtime_defaults`,
+These cover the small private helpers (`_derive_mellea_package_name`,
+`mirror_dir_contents_to_target`, `resolve_runtime_defaults`,
 `write_runtime_directive`, `build_system_prompt`) that handle the
 plumbing around the LLM-driven compile() orchestrator. None of these
 require Claude Code, an LLM, network access, or a mellea install.
@@ -15,57 +15,67 @@ import pytest
 
 from mellea_skills_compiler.compile.claude_directives import (
     build_system_prompt,
-    derive_package_name,
-    mirror_companion_dirs,
     resolve_runtime_defaults,
     write_runtime_directive,
 )
-from mellea_skills_compiler.compile.mellea_skills import _select_canonical_mellea_dir
+from mellea_skills_compiler.compile.mellea_skills import (
+    _derive_mellea_package_name,
+    _select_canonical_mellea_dir,
+)
+from mellea_skills_compiler.toolkit.file_utils import mirror_dir_contents_to_target
 
 
 class TestDerivePackageName:
     """Rule OUT-2: lowercase, hyphens/spaces -> underscores, append `_mellea`."""
 
     def test_md_spec_uses_frontmatter_name(self):
-        result = derive_package_name(Path("/x/y/spec.md"), {"name": "weather"})
+        result = _derive_mellea_package_name(Path("/x/y/spec.md"), {"name": "weather"})
         assert result == "weather_mellea"
 
     def test_md_spec_falls_back_to_parent_dir_name_when_no_frontmatter_name(self):
-        result = derive_package_name(Path("/x/weather/spec.md"), {})
+        result = _derive_mellea_package_name(Path("/x/weather/spec.md"), {})
         assert result == "weather_mellea"
 
     def test_md_spec_falls_back_to_parent_dir_name_when_frontmatter_is_none(self):
-        result = derive_package_name(Path("/x/weather/spec.md"), None)
+        result = _derive_mellea_package_name(Path("/x/weather/spec.md"), None)
         assert result == "weather_mellea"
 
     def test_dir_input_uses_directory_name(self, tmp_path):
         skill_dir = tmp_path / "crewai-job-posting"
         skill_dir.mkdir()
-        result = derive_package_name(skill_dir, None)
+        result = _derive_mellea_package_name(skill_dir, None)
         assert result == "crewai_job_posting_mellea"
 
     def test_normalises_uppercase(self):
-        result = derive_package_name(Path("/x/y/spec.md"), {"name": "WeatherSkill"})
+        result = _derive_mellea_package_name(
+            Path("/x/y/spec.md"), {"name": "WeatherSkill"}
+        )
         assert result == "weatherskill_mellea"
 
     def test_normalises_spaces(self):
-        result = derive_package_name(Path("/x/y/spec.md"), {"name": "weather skill"})
+        result = _derive_mellea_package_name(
+            Path("/x/y/spec.md"), {"name": "weather skill"}
+        )
         assert result == "weather_skill_mellea"
 
     def test_collapses_double_underscores(self):
-        result = derive_package_name(Path("/x/y/spec.md"), {"name": "weather--skill"})
+        result = _derive_mellea_package_name(
+            Path("/x/y/spec.md"), {"name": "weather--skill"}
+        )
         assert result == "weather_skill_mellea"
         assert "__" not in result
 
     def test_strips_leading_trailing_underscores(self):
-        result = derive_package_name(Path("/x/y/spec.md"), {"name": "_weather_"})
+        result = _derive_mellea_package_name(
+            Path("/x/y/spec.md"), {"name": "_weather_"}
+        )
         assert result == "weather_mellea"
 
     def test_falls_back_to_skill_for_empty_input(self):
         # Empty frontmatter name AND empty parent dir name -> safe fallback "skill".
         # Path("/spec.md").parent.name == "" so the helper's `.strip("_") or "skill"`
         # fallback kicks in.
-        result = derive_package_name(Path("/spec.md"), {"name": ""})
+        result = _derive_mellea_package_name(Path("/spec.md"), {"name": ""})
         assert result == "skill_mellea"
 
 
@@ -78,7 +88,7 @@ class TestMirrorCompanionDirs:
         (skill / "scripts" / "bash").mkdir(parents=True)
         (skill / "scripts" / "bash" / "x.sh").write_text("hello")
 
-        mirrored = mirror_companion_dirs(skill, package)
+        mirrored = mirror_dir_contents_to_target(skill, package)
 
         assert (package / "scripts" / "bash" / "x.sh").exists()
         assert (package / "scripts" / "bash" / "x.sh").read_text() == "hello"
@@ -91,7 +101,7 @@ class TestMirrorCompanionDirs:
             (skill / name).mkdir(parents=True)
             (skill / name / "file.txt").write_text(f"contents of {name}")
 
-        mirrored = mirror_companion_dirs(skill, package)
+        mirrored = mirror_dir_contents_to_target(skill, package)
 
         for name in ("scripts", "references", "assets"):
             assert (package / name / "file.txt").exists()
@@ -105,7 +115,7 @@ class TestMirrorCompanionDirs:
         (skill / "scripts").mkdir(parents=True)
         (skill / "scripts" / "x.sh").write_text("hi")
 
-        mirrored = mirror_companion_dirs(skill, package)
+        mirrored = mirror_dir_contents_to_target(skill, package)
 
         assert mirrored == ["scripts"]
         assert (package / "scripts").exists()
@@ -118,9 +128,9 @@ class TestMirrorCompanionDirs:
         (skill / "scripts").mkdir(parents=True)
         (skill / "scripts" / "x.sh").write_text("first")
 
-        first = mirror_companion_dirs(skill, package)
+        first = mirror_dir_contents_to_target(skill, package)
         # Second call must not raise (relies on dirs_exist_ok=True).
-        second = mirror_companion_dirs(skill, package)
+        second = mirror_dir_contents_to_target(skill, package)
 
         assert first == second == ["scripts"]
         assert (package / "scripts" / "x.sh").read_text() == "first"
@@ -131,7 +141,7 @@ class TestMirrorCompanionDirs:
         package = tmp_path / "nonexistent_parent" / "skill_mellea"
         assert not package.exists()
 
-        mirrored = mirror_companion_dirs(skill, package)
+        mirrored = mirror_dir_contents_to_target(skill, package)
 
         assert package.exists()
         assert package.is_dir()
@@ -142,7 +152,7 @@ class TestMirrorCompanionDirs:
         skill.mkdir()
         package = tmp_path / "skill" / "skill_mellea"
 
-        mirrored = mirror_companion_dirs(skill, package)
+        mirrored = mirror_dir_contents_to_target(skill, package)
 
         assert mirrored == []
 


### PR DESCRIPTION
Hi @ingelise 
Can you review specifically `src/mellea_skills_compiler/toolkit/file_utils.py#mirror_dir_contents_to_target()` function? This is the one we discussed in the call on having a generic copy function.

@elizabethmdaly Can you checkout the code and test changes at your end? 

**Note:** The current implementation copies all files and folders. If someone re-runs the compile command in the same skill directory, it ignores three specific items: ["audit," "pyproject.toml," and <Mellea_directory>]. The copy API includes both an **include list** and **ignore list**. We can play around to as needed.