### PR TITLE
fix: smoke-check skips un-provided external deps instead of failing

### DIFF
--- a/src/mellea_skills_compiler/compile/smoke_check.py
+++ b/src/mellea_skills_compiler/compile/smoke_check.py
@@ -181,6 +181,27 @@ def _classify_exception(
     if "401" in text or "403" in text or "unauthorized" in text.lower() or "authentication failed" in text.lower():
         return f"backend unreachable: authentication failed (check API key or env vars): {exc}"
 
+    # External HTTP service error (e.g. urllib ``HTTPError`` 4xx/5xx, raised directly
+    # or re-wrapped in a RuntimeError). The external backend the tool calls is not
+    # available in the smoke environment, so a fixture that performs a live request
+    # is exercising an un-provided external integration, not a code defect. Treat as
+    # backend-unreachable (skip) so the otherwise-valid package is not failed.
+    if cls_name == "HTTPError" or "HTTP Error 4" in text or "HTTP Error 5" in text:
+        return f"backend unreachable: external HTTP error (no live backend in smoke): {exc}"
+
+    # Unimplemented external-dependency stub. The compiler deliberately emits
+    # ``NotImplementedError`` stubs for external side effects it cannot synthesise
+    # (dependency-plan slots, e.g. constrained_slots.py). A fixture that drives such
+    # a stub is exercising an un-provided external integration, not a code defect —
+    # the package compiled correctly. Skip rather than fail (the same philosophy as
+    # the declared-dependency-missing skip above); supply/mock the implementation to
+    # run it at validation time.
+    if isinstance(exc, NotImplementedError):
+        return (
+            f"unimplemented external-dependency stub exercised by this fixture: {exc} "
+            f"The package compiled; provide or mock the dependency to run it."
+        )
+
     return None
 
 


### PR DESCRIPTION
Smoke-check skips un-provided external dependencies instead of failing

  An otherwise-valid compiled package is hard-failed when smoke exercises an external side effect that can't
  run in the smoke environment. Reclassifies two cases as skipped (environmental — consistent with the
  existing declared-dependency / backend-unreachable skips) rather than failed, in _classify_exception:

  - Unimplemented dependency stub: the compiler deliberately emits NotImplementedError stubs for external
  deps it can't synthesize (dependency-plan slots, e.g. constrained_slots.py); driving one shouldn't fail the
  compile.
  - Live external HTTP call: an outbound request returning 4xx/5xx with no backend present in smoke.

  The package compiles; supply or mock the dependency to run it at validation time.

  File: compile/smoke_check.py. Verified: slack + appdeploy compile through; a real AttributeError still
  fails (no over-skipping).