### PR TITLE
fix: guard invalid package names and non-executable bundled scripts

### DIFF
--- a/src/mellea_skills_compiler/compile/mellea_skills.py
+++ b/src/mellea_skills_compiler/compile/mellea_skills.py
@@ -139,6 +139,12 @@ def _derive_mellea_package_name(spec_path: Path, frontmatter: Optional[Dict]) ->
     while "__" in name:
         name = name.replace("__", "_")
     name = name.strip("_") or "skill"
+    # Rule OUT-2 guard: a Python package/module name cannot start with a digit
+    # (e.g. skill id "1password" -> "1password_mellea" is an invalid identifier and
+    # the package is unimportable). Prefix an underscore so the name is a valid
+    # identifier while staying recognisable.
+    if name[0].isdigit():
+        name = f"_{name}"
     return f"{name}_mellea"
 
 

--- a/src/mellea_skills_compiler/toolkit/file_utils.py
+++ b/src/mellea_skills_compiler/toolkit/file_utils.py
@@ -1,6 +1,7 @@
 import importlib
 import re
 import shutil
+import stat
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -230,5 +231,28 @@ def mirror_dir_contents_to_target(
             mirrored.append(source.name)
         except Exception as e:
             LOGGER.warning(f"Failed to mirror {source.name}: {e}")
+
+    # Ensure bundled script assets stay executable. Compiled tools invoke
+    # companion scripts by path (e.g. subprocess.run([".../foo.sh", ...])),
+    # which requires the executable bit. Source skills frequently ship scripts
+    # without +x (and shutil.copy2 preserves that), so a mirrored `.sh` /
+    # shebang script raises PermissionError at runtime. Set +x here so the
+    # mirrored scripts are runnable regardless of the source mode bits.
+    for path in target_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        is_script = path.suffix == ".sh"
+        if not is_script:
+            try:
+                with path.open("rb") as fh:
+                    is_script = fh.read(2) == b"#!"
+            except OSError:
+                is_script = False
+        if is_script:
+            try:
+                mode = path.stat().st_mode
+                path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            except OSError as e:
+                LOGGER.warning(f"Failed to set +x on mirrored script {path.name}: {e}")
 
     return mirrored


### PR DESCRIPTION
 Guard invalid package names + make bundled scripts executable

  Fixes two deterministic compile failures where the generated package is unusable:
  
  - Invalid package name: a skill id starting with a digit (e.g. 1password) yields 1password_mellea, not a
  valid Python identifier — import fails (SyntaxError: invalid decimal literal), failing the parseable lint.
  Adds a leading-digit guard in _derive_mellea_package_name (prefixes _).
  - Non-executable bundled script: mirrored .sh assets keep their source 0644 perms, so the compiled tool's
  subprocess.run([".../foo.sh", …]) raises PermissionError. Sets +x on .sh/shebang assets in
  mirror_dir_contents_to_target.

  Files: compile/mellea_skills.py, toolkit/file_utils.py. Verified: 1password → _1password_mellea (imports);