### PR TITLE
feat: contract-conformance repairs + lints for deterministic codegen

### DIFF
--- a/src/mellea_skills_compiler/compile/lints.py
+++ b/src/mellea_skills_compiler/compile/lints.py
@@ -1260,6 +1260,16 @@ def lint_fixture_pydantic_coercion(package_dir: Path) -> LintResult:
     pydantic_classes = _find_pydantic_classes_in_schemas(schemas_py)
     pydantic_params = _pydantic_typed_run_pipeline_params(pipeline_py, pydantic_classes)
 
+    # Credit entry coercion: a param guarded by ``if isinstance(p, dict): p = Cls(**p)``
+    # at run_pipeline entry is safe to receive a bare-dict fixture input (fix option
+    # (b) in this lint's own message), so do not flag it. Lazy import to avoid a
+    # circular import with the repairs module.
+    from mellea_skills_compiler.compile.repairs import params_coerced_at_entry
+
+    coerced = params_coerced_at_entry(pipeline_py)
+    if coerced:
+        pydantic_params = {p: c for p, c in pydantic_params.items() if p not in coerced}
+
     if not pydantic_params:
         return result
 
@@ -2323,7 +2333,80 @@ def lint_parseable(package_dir: Path) -> LintResult:
 # ─── Runner ───
 
 
+_KNOWN_SESSION_METHODS = {
+    "instruct", "ainstruct", "act", "aact", "chat", "achat", "query", "aquery",
+    "validate", "avalidate", "transform", "atransform", "clone", "reset",
+    "cleanup", "powerup", "last_prompt",
+}
+
+
+def lint_session_method_exists(package_dir: Path) -> LintResult:
+    """Reject calls to MelleaSession methods that do not exist.
+
+    The LLM writer sometimes invents a session method (observed: ``m.react(...)``
+    with fabricated ``tools=``/``loop_budget=`` kwargs). Such code passes structural
+    checks and only dies at smoke with ``AttributeError: 'MelleaSession' object has
+    no attribute 'react'``. Catching it at Step 7 lets the repair loop fix it (use a
+    real method such as ``m.instruct`` / ``m.act``) before smoke.
+    """
+    result = LintResult(lint_id="session-method-exists", verdict="pass")
+    pipeline_py = package_dir / "pipeline.py"
+    if not pipeline_py.is_file():
+        result.verdict = "skipped"
+        result.skipped_reason = "pipeline.py not found"
+        return result
+    try:
+        tree = ast.parse(pipeline_py.read_text(encoding="utf-8"))
+    except SyntaxError:
+        result.verdict = "skipped"
+        result.skipped_reason = "pipeline.py not parseable"
+        return result
+
+    session_vars: set = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.With):
+            for item in node.items:
+                ctx = item.context_expr
+                if (
+                    isinstance(ctx, ast.Call)
+                    and isinstance(ctx.func, ast.Name)
+                    and ctx.func.id == "start_session"
+                    and isinstance(item.optional_vars, ast.Name)
+                ):
+                    session_vars.add(item.optional_vars.id)
+    if not session_vars:
+        return result
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in session_vars
+            and node.func.attr not in _KNOWN_SESSION_METHODS
+            and not node.func.attr.startswith("_")
+        ):
+            result.failures.append(
+                LintFailure(
+                    file="pipeline.py",
+                    line=node.lineno,
+                    column=node.col_offset,
+                    message=(
+                        f"`{node.func.value.id}.{node.func.attr}(...)` calls a "
+                        f"MelleaSession method that does not exist. Use a real "
+                        f"session method (e.g. m.instruct, m.act, m.chat, m.query). "
+                        f"Hallucinated methods raise AttributeError at smoke-check time."
+                    ),
+                    rule_ref="session-method-exists",
+                )
+            )
+    if result.failures:
+        result.verdict = "fail"
+    return result
+
+
 ALL_LINTS: Tuple[Callable[[Path], LintResult], ...] = (
+    lint_session_method_exists,
     lint_fixtures_loader_contract,
     lint_bundled_asset_path_resolution,
     lint_runtime_defaults_bound,

--- a/src/mellea_skills_compiler/compile/mellea_skills.py
+++ b/src/mellea_skills_compiler/compile/mellea_skills.py
@@ -148,6 +148,19 @@ def validate(package_dir: Path, *, no_run: bool, all_fixtures: bool) -> None:
         raise Exception(f"Package directory does not exist: {package_dir}")
 
     from mellea_skills_compiler.compile.lints import run_lints
+    from mellea_skills_compiler.compile.repairs import (
+        coerce_pydantic_params_at_entry,
+        escape_grounding_context_values,
+    )
+
+    # Deterministic pre-lint repairs (contract conformance):
+    #  - make run_pipeline tolerant of bare-dict fixture inputs for Pydantic-typed
+    #    params (otherwise the fixture-shape mismatch raises AttributeError at smoke);
+    #  - wrap grounding_context values so incidental Jinja syntax in the data
+    #    ({% csrf_token %} in code under review, {{ }} in fetched docs) is rendered
+    #    literally instead of raising TemplateSyntaxError / UndefinedError.
+    coerce_pydantic_params_at_entry(package_dir)
+    escape_grounding_context_values(package_dir)
 
     lint_result = run_lints(package_dir)
     if lint_result.failed:

--- a/src/mellea_skills_compiler/compile/repairs.py
+++ b/src/mellea_skills_compiler/compile/repairs.py
@@ -1,0 +1,226 @@
+"""Deterministic post-generation repairs applied to a compiled package before lints.
+
+These fix structural mismatches the LLM writer can introduce, so the emitted
+package honours its own typed contracts without depending on the model getting
+every detail right.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List
+
+from mellea_skills_compiler.compile.lints import (
+    _find_pydantic_classes_in_schemas,
+    _resolve_pydantic_annotation,
+)
+from mellea_skills_compiler.toolkit.logging import configure_logger
+
+LOGGER = configure_logger(__name__)
+
+_MARKER = "# [pydantic-coercion]"
+
+
+def params_coerced_at_entry(pipeline_py: Path) -> set:
+    """Return run_pipeline params already guarded by ``if isinstance(p, dict): ...``.
+
+    Shared by the repair (to avoid double-injecting) and the
+    ``fixture-pydantic-coercion`` lint (to credit entry coercion as a valid fix).
+    """
+    try:
+        tree = ast.parse(pipeline_py.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return set()
+    func = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "run_pipeline"),
+        None,
+    )
+    if func is None:
+        return set()
+    coerced = set()
+    for stmt in func.body:
+        if not isinstance(stmt, ast.If) or not isinstance(stmt.test, ast.Call):
+            continue
+        test = stmt.test
+        if (
+            isinstance(test.func, ast.Name)
+            and test.func.id == "isinstance"
+            and len(test.args) == 2
+            and isinstance(test.args[0], ast.Name)
+            and isinstance(test.args[1], ast.Name)
+            and test.args[1].id == "dict"
+        ):
+            coerced.add(test.args[0].id)
+    return coerced
+
+
+def coerce_pydantic_params_at_entry(package_dir: Path) -> List[str]:
+    """Make ``run_pipeline`` tolerant of bare-dict inputs for Pydantic-typed params.
+
+    Fixtures emit plain dict literals for structured inputs, but ``run_pipeline``
+    frequently types those parameters as Pydantic models and then accesses
+    attributes on them — which raises ``AttributeError: 'dict' object has no
+    attribute ...`` at smoke-check time (lint ``fixture-pydantic-coercion``).
+
+    This injects ``if isinstance(p, dict): p = Cls(**p)`` at the top of
+    ``run_pipeline`` for each parameter whose annotation resolves to a Pydantic
+    model defined in ``schemas.py``. The model classes are already imported in
+    ``pipeline.py`` (they are used as annotations), so no new imports are needed.
+
+    Idempotent (guarded by a marker comment); preserves the rest of the file.
+    Returns the list of parameter names that were coerced.
+    """
+    pipeline_py = package_dir / "pipeline.py"
+    schemas_py = package_dir / "schemas.py"
+    if not pipeline_py.is_file():
+        return []
+
+    pydantic = _find_pydantic_classes_in_schemas(schemas_py)
+    if not pydantic:
+        return []
+
+    src = pipeline_py.read_text(encoding="utf-8")
+    if _MARKER in src:  # already applied
+        return []
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return []
+
+    func = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "run_pipeline"),
+        None,
+    )
+    if func is None or not func.body:
+        return []
+
+    already = params_coerced_at_entry(pipeline_py)
+    inject = []
+    for arg in func.args.args:
+        if arg.annotation is None or arg.arg in already:
+            continue
+        cls = _resolve_pydantic_annotation(arg.annotation, pydantic)
+        if cls:
+            inject.append((arg.arg, cls))
+    if not inject:
+        return []
+
+    # Insert immediately before the first real (non-docstring) body statement so
+    # the indentation matches and a leading docstring is preserved.
+    body = func.body
+    first = body[0]
+    is_docstring = (
+        isinstance(first, ast.Expr)
+        and isinstance(getattr(first, "value", None), ast.Constant)
+        and isinstance(first.value.value, str)
+    )
+    anchor = body[1] if (is_docstring and len(body) > 1) else first
+    insert_idx = anchor.lineno - 1  # 0-based line index to insert before
+    indent = " " * anchor.col_offset
+
+    snippet = [f"{indent}{_MARKER} tolerate dict fixture inputs for typed params\n"]
+    for pname, cls in inject:
+        snippet.append(f"{indent}if isinstance({pname}, dict):\n")
+        snippet.append(f"{indent}    {pname} = {cls}(**{pname})\n")
+
+    lines = src.splitlines(keepends=True)
+    new_lines = lines[:insert_idx] + snippet + lines[insert_idx:]
+    new_src = "".join(new_lines)
+
+    # Safety: only write if the result still parses.
+    try:
+        ast.parse(new_src)
+    except SyntaxError:
+        LOGGER.warning("pydantic-coercion repair produced unparseable pipeline.py; skipping")
+        return []
+
+    pipeline_py.write_text(new_src, encoding="utf-8")
+    coerced = [p for p, _ in inject]
+    LOGGER.info("Applied pydantic-coercion repair to run_pipeline params: %s", ", ".join(coerced))
+    return coerced
+
+
+_HELPER_NAME = "_ground_literal"
+_HELPER_SRC = (
+    f'\n\ndef {_HELPER_NAME}(_v):\n'
+    '    """Wrap grounding data so Mellea\'s Jinja rendering treats it literally.\n\n'
+    "    Mellea renders grounding_context VALUES as Jinja templates\n"
+    "    (Instruction.apply_user_dict_from_jinja). When a value is data that happens\n"
+    "    to contain ``{{ }}`` / ``{% %}`` (fetched API docs, code under review, etc.)\n"
+    "    Jinja mis-parses it and raises UndefinedError / TemplateSyntaxError. Wrapping\n"
+    "    in a raw block makes Jinja emit the content verbatim.\n"
+    '    """\n'
+    '    return "{% raw %}" + str(_v) + "{% endraw %}"\n'
+)
+
+
+def escape_grounding_context_values(package_dir: Path) -> List[str]:
+    """Wrap every ``grounding_context={...}`` value so incidental Jinja syntax in the
+    data is not executed as a template. Idempotent; preserves the rest of the file.
+    Returns the list of source segments wrapped.
+    """
+    pipeline_py = package_dir / "pipeline.py"
+    if not pipeline_py.is_file():
+        return []
+    src = pipeline_py.read_text(encoding="utf-8")
+    if _HELPER_NAME in src:  # already applied
+        return []
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return []
+
+    lines = src.splitlines(keepends=True)
+    line_start = [0]
+    for ln in lines:
+        line_start.append(line_start[-1] + len(ln))
+
+    def offset(lineno: int, col: int) -> int:
+        return line_start[lineno - 1] + col
+
+    # Collect (start, end) char spans of every value in a grounding_context dict.
+    spans = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "grounding_context" and isinstance(kw.value, ast.Dict):
+                for k, v in zip(kw.value.keys, kw.value.values):
+                    # Skip ``**unpacking`` entries: ast.Dict represents `{**X}` with a
+                    # None key and X as the value. Wrapping X would turn `{**X}` into
+                    # `{**_ground_literal(X)}` (i.e. `**<str>`) → "'str' object is not a
+                    # mapping". Only wrap explicitly-keyed string values.
+                    if k is None or v.end_lineno is None:
+                        continue
+                    spans.append((offset(v.lineno, v.col_offset),
+                                  offset(v.end_lineno, v.end_col_offset)))
+    if not spans:
+        return []
+
+    wrapped = []
+    new = src
+    for s, e in sorted(spans, reverse=True):  # splice from end to keep offsets valid
+        seg = new[s:e]
+        wrapped.append(seg)
+        new = f"{new[:s]}{_HELPER_NAME}({seg}){new[e:]}"
+
+    # Inject the helper after the last top-level import.
+    insert_line = 0
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and getattr(node, "col_offset", 1) == 0:
+            insert_line = max(insert_line, node.end_lineno or node.lineno)
+    helper_at = line_start[insert_line]  # char offset just after that import line
+    new = new[:helper_at] + _HELPER_SRC + new[helper_at:]
+
+    try:
+        ast.parse(new)
+    except SyntaxError:
+        LOGGER.warning("grounding-escape repair produced unparseable pipeline.py; skipping")
+        return []
+
+    pipeline_py.write_text(new, encoding="utf-8")
+    LOGGER.info("Applied grounding-escape repair to %d grounding_context value(s)", len(wrapped))
+    return wrapped


### PR DESCRIPTION
 Problem

  A class of compile failures only surfaces at the smoke stage — which does not trigger the repair loop — and
  because the Mellea-fy pass is LLM-generated, which one appears varies run to run. Three recurring shapes:

  - Fixture/type mismatch: a fixture passes a bare dict where run_pipeline types the parameter as a Pydantic
  model, so the first attribute access raises AttributeError: 'dict' object has no attribute … at smoke.
  - Grounding template injection: input or fetched data containing Jinja syntax ({% csrf_token %} in code
  under review, {{ }} in fetched API docs) is rendered as a template by Mellea's grounding, raising
  TemplateSyntaxError / UndefinedError.
  - Hallucinated session API: the writer invents a MelleaSession method (observed: m.react(...) with
  fabricated kwargs), which dies at smoke with AttributeError: … has no attribute 'react'.

  Fix

  Convert these into deterministic early outcomes — auto-repaired before lints, or caught by a lint the
  existing repair loop can act on. Pure Python; no mellea-fy prompt changes.
  
  - Pydantic coercion (repair): inject if isinstance(p, dict): p = Model(**p) at run_pipeline entry for
  Pydantic-typed params; the fixture-pydantic-coercion lint now credits entry coercion.
  - Grounding-escape (repair): wrap grounding_context values in {% raw %}…{% endraw %} so incidental Jinja in
  the data renders literally. Skips **-unpack entries; safe because grounding values are always pure data
  across the corpus.
  - Session-method lint (reject): flag calls to non-existent MelleaSession methods at Step 7, so the repair
  loop fixes them before smoke.

  Changes

  - New compile/repairs.py (coercion + grounding-escape), wired into validate() before lints.
  - compile/lints.py: lint_session_method_exists + entry-coercion crediting.
  - compile/mellea_skills.py: repair hooks.

  Verification

  - Offline corpus tests (deterministic): coercion makes the lint pass, grounding wraps values and
  neutralizes {% csrf_token %}, session-lint catches m.react.
  - Clean compile: anthropic-doc-coauthoring and sergiodxa-owasp-security-check both compile green end-to-end
  (the latter previously died on TemplateSyntaxError: csrf_token).