### PR TITLE
Smoke-Test run single fixture fix

### DIFF
--- a/src/mellea_skills_compiler/compile/claude_directives.py
+++ b/src/mellea_skills_compiler/compile/claude_directives.py
@@ -11,7 +11,7 @@ LOGGER = configure_logger()
 # Defaults for the LLM backend and model that compiled skills use at runtime.
 # Sourced from .claude/data/runtime_defaults.json with optional CLI overrides.
 _RUNTIME_DEFAULTS_PATH = Path(".claude/data/runtime_defaults.json")
-_RUNTIME_DEFAULTS_FALLBACK = {"backend": "ollama", "model_id": "granite4.1:3B"}
+_RUNTIME_DEFAULTS_FALLBACK = {"backend": "ollama", "model_id": "granite4.1:3b"}
 
 
 def resolve_runtime_defaults(

--- a/src/mellea_skills_compiler/compile/smoke_check.py
+++ b/src/mellea_skills_compiler/compile/smoke_check.py
@@ -26,6 +26,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from mellea_skills_compiler.models import Fixture
 from mellea_skills_compiler.toolkit.file_utils import (
     load_fixtures,
     load_skill_pipeline,
@@ -166,20 +167,41 @@ def _classify_exception(
             )
 
     # stdlib network errors
-    if isinstance(exc, (ConnectionError, ConnectionRefusedError, ConnectionAbortedError, ConnectionResetError)):
+    if isinstance(
+        exc,
+        (
+            ConnectionError,
+            ConnectionRefusedError,
+            ConnectionAbortedError,
+            ConnectionResetError,
+        ),
+    ):
         return f"backend unreachable: {cls_name}: {exc}"
     if isinstance(exc, TimeoutError):
         return f"backend unreachable: timeout: {exc}"
 
     # httpx / requests / urllib3 — name-matched to avoid import dependencies
-    if cls_name in ("ConnectError", "ConnectTimeout", "ReadTimeout", "PoolTimeout", "RemoteProtocolError"):
+    if cls_name in (
+        "ConnectError",
+        "ConnectTimeout",
+        "ReadTimeout",
+        "PoolTimeout",
+        "RemoteProtocolError",
+    ):
         return f"backend unreachable: {cls_module}.{cls_name}: {exc}"
-    if cls_name == "ConnectionError" and cls_module.startswith(("requests", "urllib3", "httpx", "httpcore")):
+    if cls_name == "ConnectionError" and cls_module.startswith(
+        ("requests", "urllib3", "httpx", "httpcore")
+    ):
         return f"backend unreachable: {cls_module}.{cls_name}: {exc}"
 
     # HTTP auth from various libs (string match — APIs vary widely)
     text = str(exc)
-    if "401" in text or "403" in text or "unauthorized" in text.lower() or "authentication failed" in text.lower():
+    if (
+        "401" in text
+        or "403" in text
+        or "unauthorized" in text.lower()
+        or "authentication failed" in text.lower()
+    ):
         return f"backend unreachable: authentication failed (check API key or env vars): {exc}"
 
     # External HTTP service error (e.g. urllib ``HTTPError`` 4xx/5xx, raised directly
@@ -208,24 +230,22 @@ def _classify_exception(
 
 def _run_one_fixture(
     pipeline_fn,
-    fixture: Dict[str, Any],
+    fixture: Fixture,
     skill_dir: Optional[Path] = None,
     package_dir: Optional[Path] = None,
 ) -> SmokeFixtureResult:
-    fixture_id = fixture.get("id", "<unknown>")
     started = time.time()
     try:
-        context = fixture["context"]
         # Run the fixture from the package directory so package-relative input
         # paths (e.g. 'references/example_patient.json' bundled in the package)
         # resolve the same way they do for an installed skill, rather than
         # against the compiler's CWD. contextlib.chdir restores CWD afterward.
         run_dir = package_dir if package_dir is not None else Path.cwd()
         with contextlib.chdir(run_dir):
-            if isinstance(context, dict):
-                pipeline_fn(**context)
+            if isinstance(fixture.context, dict):
+                pipeline_fn(**fixture.context)
             else:
-                pipeline_fn(context)
+                pipeline_fn(fixture.context)
     except BaseException as exc:  # noqa: BLE001 — we re-classify all
         duration = time.time() - started
         skipped_reason = _classify_exception(exc, skill_dir=skill_dir)
@@ -236,20 +256,22 @@ def _run_one_fixture(
                 skipped_reason,
             )
             return SmokeFixtureResult(
-                fixture_id=fixture_id,
+                fixture_id=fixture.id,
                 verdict="skipped",
                 duration_seconds=duration,
                 skipped_reason=skipped_reason,
             )
         return SmokeFixtureResult(
-            fixture_id=fixture_id,
+            fixture_id=fixture.id,
             verdict="failed",
             duration_seconds=duration,
             failure_message=f"{type(exc).__name__}: {exc}",
-            failure_traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            failure_traceback="".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            ),
         )
     return SmokeFixtureResult(
-        fixture_id=fixture_id,
+        fixture_id=fixture.id,
         verdict="passed",
         duration_seconds=time.time() - started,
     )

--- a/src/mellea_skills_compiler/toolkit/file_utils.py
+++ b/src/mellea_skills_compiler/toolkit/file_utils.py
@@ -65,7 +65,7 @@ def load_skill_pipeline(pipeline_dir: Path):
         skill_pipeline = importlib.import_module(f"{pipeline_dir.name}.pipeline")
     except ModuleNotFoundError as e:
         raise Exception(
-            f"Error loading pipeline module `{pipeline_dir.name}.pipeline`. Please verify that the module exists and that all imports are correct."
+            f"Error loading pipeline module `{pipeline_dir.name}.pipeline`. {str(e)}."
         )
     finally:
         # Remove parent directory from sys.path
@@ -158,7 +158,7 @@ def load_fixtures(pipeline_dir: Path) -> List[Fixture]:
                 )
     except ImportError:
         raise Exception(
-            f"The `__init__.py` module is missing from the fixture directory - {fixtures_dir}"
+            f"Error loading fixtures from `{fixtures_dir}`. {str(e)}."
         )
     finally:
         sys.path.pop(0)

--- a/src/mellea_skills_compiler/toolkit/file_utils.py
+++ b/src/mellea_skills_compiler/toolkit/file_utils.py
@@ -65,7 +65,7 @@ def load_skill_pipeline(pipeline_dir: Path):
         skill_pipeline = importlib.import_module(f"{pipeline_dir.name}.pipeline")
     except ModuleNotFoundError as e:
         raise Exception(
-            f"Error: The `pipeline.py` module is missing from the pipeline directory - {pipeline_dir}"
+            f"Error loading pipeline module `{pipeline_dir.name}.pipeline`. Please verify that the module exists and that all imports are correct."
         )
     finally:
         # Remove parent directory from sys.path

--- a/src/mellea_skills_compiler/toolkit/file_utils.py
+++ b/src/mellea_skills_compiler/toolkit/file_utils.py
@@ -3,8 +3,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import yaml
 from rich.console import Console
@@ -156,10 +155,8 @@ def load_fixtures(pipeline_dir: Path) -> List[Fixture]:
                 fixtures.append(
                     Fixture(id=fixture_id, context=inputs, description=description)
                 )
-    except ImportError:
-        raise Exception(
-            f"Error loading fixtures from `{fixtures_dir}`. {str(e)}."
-        )
+    except ImportError as e:
+        raise Exception(f"Error loading fixtures from `{fixtures_dir}`. {str(e)}.")
     finally:
         sys.path.pop(0)
 

--- a/tests/mellea_skills_compiler/compile/test_lints.py
+++ b/tests/mellea_skills_compiler/compile/test_lints.py
@@ -405,10 +405,10 @@ class TestRuntimeDefaultsBound:
 
     def test_passes_when_config_matches_directive(self):
         """config.py with matching BACKEND/MODEL_ID should pass."""
-        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3B"\n'
+        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3b"\n'
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = lint_runtime_defaults_bound(pkg)
             assert result.verdict == "pass", (
                 f"Matching config and directive should pass; got {result.verdict} "
@@ -417,10 +417,10 @@ class TestRuntimeDefaultsBound:
 
     def test_fails_when_backend_diverges(self):
         """config.py BACKEND != directive backend → fail with actionable message."""
-        config = 'BACKEND = "watsonx"\n' 'MODEL_ID = "granite4.1:3B"\n'
+        config = 'BACKEND = "watsonx"\n' 'MODEL_ID = "granite4.1:3b"\n'
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = lint_runtime_defaults_bound(pkg)
             assert (
                 result.verdict == "fail"
@@ -442,7 +442,7 @@ class TestRuntimeDefaultsBound:
         config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite3.3:2b"\n'
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = lint_runtime_defaults_bound(pkg)
             assert (
                 result.verdict == "fail"
@@ -450,14 +450,14 @@ class TestRuntimeDefaultsBound:
             assert len(result.failures) == 1
             msg = result.failures[0].message
             assert "granite3.3:2b" in msg
-            assert "granite4.1:3B" in msg
+            assert "granite4.1:3b" in msg
 
     def test_fails_when_backend_constant_missing(self):
         """config.py without BACKEND → fail with a clear message naming BACKEND."""
-        config = 'MODEL_ID = "granite4.1:3B"\n'
+        config = 'MODEL_ID = "granite4.1:3b"\n'
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = lint_runtime_defaults_bound(pkg)
             assert (
                 result.verdict == "fail"
@@ -476,7 +476,7 @@ class TestRuntimeDefaultsBound:
 
     def test_skipped_when_directive_missing(self):
         """No intermediate/runtime_directive.json → skipped with 'older pipeline' reason."""
-        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3B"\n'
+        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3b"\n'
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
             result = lint_runtime_defaults_bound(pkg)
@@ -492,7 +492,7 @@ class TestRuntimeDefaultsBound:
         """No config.py → skipped."""
         with tempfile.TemporaryDirectory() as tmp:
             pkg = Path(tmp)
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = lint_runtime_defaults_bound(pkg)
             assert (
                 result.verdict == "skipped"
@@ -502,7 +502,7 @@ class TestRuntimeDefaultsBound:
 
     def test_skipped_when_directive_malformed_json(self):
         """Malformed JSON in runtime_directive.json → skipped with parse-error reason."""
-        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3B"\n'
+        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3b"\n'
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
             (pkg / "intermediate").mkdir(parents=True, exist_ok=True)
@@ -524,11 +524,11 @@ class TestRuntimeDefaultsBound:
         config = (
             "from typing import Final\n"
             'BACKEND: Final[str] = "ollama"\n'
-            'MODEL_ID: Final[str] = "granite4.1:3B"\n'
+            'MODEL_ID: Final[str] = "granite4.1:3b"\n'
         )
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = lint_runtime_defaults_bound(pkg)
             assert result.verdict == "pass", (
                 f"Annotated BACKEND/MODEL_ID assignments should be recognised; "
@@ -538,10 +538,10 @@ class TestRuntimeDefaultsBound:
 
     def test_handles_plain_assignment(self):
         """config.py using BACKEND = 'ollama' (no annotation) should validate."""
-        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3B"\n'
+        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3b"\n'
         with tempfile.TemporaryDirectory() as tmp:
             pkg = _make_package(Path(tmp), {"config.py": config})
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = lint_runtime_defaults_bound(pkg)
             assert result.verdict == "pass", (
                 f"Plain BACKEND/MODEL_ID assignments should be recognised; "
@@ -558,7 +558,7 @@ class TestRunLints:
 
     def test_overall_pass_when_all_pass(self):
         """A compliant synthetic package should yield overall_verdict == 'pass'."""
-        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3B"\n'
+        config = 'BACKEND = "ollama"\n' 'MODEL_ID = "granite4.1:3b"\n'
         tools = (
             "from pathlib import Path\n"
             "p = Path(__file__).parent / 'scripts' / 'bash' / 'x.sh'\n"
@@ -579,7 +579,7 @@ class TestRunLints:
                     "tools.py": tools,
                 },
             )
-            _write_directive(pkg, "ollama", "granite4.1:3B")
+            _write_directive(pkg, "ollama", "granite4.1:3b")
             result = run_lints(pkg)
             assert result.overall_verdict == "pass", (
                 f"Compliant package should pass overall; got {result.overall_verdict} "

--- a/tests/mellea_skills_compiler/compile/test_mellea_skills_helpers.py
+++ b/tests/mellea_skills_compiler/compile/test_mellea_skills_helpers.py
@@ -168,33 +168,33 @@ class TestResolveRuntimeDefaults:
     def test_uses_defaults_file_when_no_override(self, tmp_path, monkeypatch):
         self._write_defaults(
             tmp_path,
-            json.dumps({"backend": "ollama", "model_id": "granite4.1:3B"}),
+            json.dumps({"backend": "ollama", "model_id": "granite4.1:3b"}),
         )
         monkeypatch.chdir(tmp_path)
 
         backend, model_id, source = resolve_runtime_defaults(None, None)
 
         assert backend == "ollama"
-        assert model_id == "granite4.1:3B"
+        assert model_id == "granite4.1:3b"
         assert "defaults file" in source
 
     def test_cli_backend_override_wins(self, tmp_path, monkeypatch):
         self._write_defaults(
             tmp_path,
-            json.dumps({"backend": "ollama", "model_id": "granite4.1:3B"}),
+            json.dumps({"backend": "ollama", "model_id": "granite4.1:3b"}),
         )
         monkeypatch.chdir(tmp_path)
 
         backend, model_id, source = resolve_runtime_defaults("vllm", None)
 
         assert backend == "vllm"
-        assert model_id == "granite4.1:3B"
+        assert model_id == "granite4.1:3b"
         assert "command-line override" in source
 
     def test_cli_both_overrides_win(self, tmp_path, monkeypatch):
         self._write_defaults(
             tmp_path,
-            json.dumps({"backend": "ollama", "model_id": "granite4.1:3B"}),
+            json.dumps({"backend": "ollama", "model_id": "granite4.1:3b"}),
         )
         monkeypatch.chdir(tmp_path)
 
@@ -211,7 +211,7 @@ class TestResolveRuntimeDefaults:
         backend, model_id, source = resolve_runtime_defaults(None, None)
 
         assert backend == "ollama"
-        assert model_id == "granite4.1:3B"
+        assert model_id == "granite4.1:3b"
         assert "built-in fallback" in source
 
     def test_falls_back_to_builtin_when_file_malformed(self, tmp_path, monkeypatch):
@@ -225,7 +225,7 @@ class TestResolveRuntimeDefaults:
         # string because the try/except short-circuits before the source
         # is updated.
         assert backend == "ollama"
-        assert model_id == "granite4.1:3B"
+        assert model_id == "granite4.1:3b"
         assert "built-in fallback" in source
 
     def test_falls_back_to_builtin_when_file_missing_keys(self, tmp_path, monkeypatch):
@@ -239,7 +239,7 @@ class TestResolveRuntimeDefaults:
         backend, model_id, source = resolve_runtime_defaults(None, None)
 
         assert backend == "ollama"
-        assert model_id == "granite4.1:3B"
+        assert model_id == "granite4.1:3b"
         assert "defaults file" in source
 
 
@@ -250,7 +250,7 @@ class TestWriteRuntimeDirective:
         intermediate = tmp_path / "intermediate"
 
         path = write_runtime_directive(
-            intermediate, "ollama", "granite4.1:3B", "defaults file (...)"
+            intermediate, "ollama", "granite4.1:3b", "defaults file (...)"
         )
 
         assert path == intermediate / "runtime_directive.json"
@@ -258,14 +258,14 @@ class TestWriteRuntimeDirective:
         data = json.loads(path.read_text())
         assert data["format_version"] == "1.0"
         assert data["backend"] == "ollama"
-        assert data["model_id"] == "granite4.1:3B"
+        assert data["model_id"] == "granite4.1:3b"
         assert data["source"] == "defaults file (...)"
 
     def test_creates_intermediate_dir_if_missing(self, tmp_path):
         intermediate = tmp_path / "deep" / "nested" / "intermediate"
         assert not intermediate.exists()
 
-        write_runtime_directive(intermediate, "ollama", "granite4.1:3B", "src")
+        write_runtime_directive(intermediate, "ollama", "granite4.1:3b", "src")
 
         assert intermediate.exists()
         assert (intermediate / "runtime_directive.json").exists()
@@ -273,7 +273,7 @@ class TestWriteRuntimeDirective:
     def test_returns_path_to_written_file(self, tmp_path):
         intermediate = tmp_path / "intermediate"
 
-        path = write_runtime_directive(intermediate, "ollama", "granite4.1:3B", "src")
+        path = write_runtime_directive(intermediate, "ollama", "granite4.1:3b", "src")
 
         assert isinstance(path, Path)
         assert path.exists()
@@ -282,7 +282,7 @@ class TestWriteRuntimeDirective:
     def test_overwrites_existing_directive(self, tmp_path):
         intermediate = tmp_path / "intermediate"
 
-        write_runtime_directive(intermediate, "ollama", "granite4.1:3B", "first")
+        write_runtime_directive(intermediate, "ollama", "granite4.1:3b", "first")
         path = write_runtime_directive(intermediate, "vllm", "mistral-7b", "second")
 
         data = json.loads(path.read_text())
@@ -296,24 +296,24 @@ class TestBuildSystemPrompt:
 
     def test_includes_backend_value(self):
         prompt = build_system_prompt(
-            "ollama", "granite4.1:3B", "defaults file", "weather_mellea"
+            "ollama", "granite4.1:3b", "defaults file", "weather_mellea"
         )
         assert "ollama" in prompt
 
     def test_includes_model_id_value(self):
         prompt = build_system_prompt(
-            "ollama", "granite4.1:3B", "defaults file", "weather_mellea"
+            "ollama", "granite4.1:3b", "defaults file", "weather_mellea"
         )
-        assert "granite4.1:3B" in prompt
+        assert "granite4.1:3b" in prompt
 
     def test_includes_source(self):
         prompt = build_system_prompt(
-            "ollama", "granite4.1:3B", "defaults file (xyz.json)", "weather_mellea"
+            "ollama", "granite4.1:3b", "defaults file (xyz.json)", "weather_mellea"
         )
         assert "defaults file (xyz.json)" in prompt
 
     def test_includes_autonomous_run_directive(self):
-        prompt = build_system_prompt("ollama", "granite4.1:3B", "src", "weather_mellea")
+        prompt = build_system_prompt("ollama", "granite4.1:3b", "src", "weather_mellea")
         assert "Run the complete 10-step pipeline" in prompt
 
     def test_quotes_values_with_repr(self):
@@ -321,10 +321,10 @@ class TestBuildSystemPrompt:
         # rather than splatted in bare. The repr of "o'l'l'ama" wraps it
         # in double quotes (Python's repr picks the safer quote style).
         prompt = build_system_prompt(
-            "o'l'l'ama", "granite4.1:3B", "src", "weather_mellea"
+            "o'l'l'ama", "granite4.1:3b", "src", "weather_mellea"
         )
         assert repr("o'l'l'ama") in prompt
-        assert repr("granite4.1:3B") in prompt
+        assert repr("granite4.1:3b") in prompt
 
     def test_injects_package_name_literally(self):
         """The wrapper-computed package_name appears verbatim in the prompt."""

--- a/tests/mellea_skills_compiler/compile/test_smoke_check.py
+++ b/tests/mellea_skills_compiler/compile/test_smoke_check.py
@@ -12,6 +12,7 @@ from mellea_skills_compiler.compile.smoke_check import (
     _run_one_fixture,
     run_smoke_check,
 )
+from mellea_skills_compiler.models import Fixture
 
 
 class TestClassifyException:
@@ -46,9 +47,7 @@ class TestClassifyException:
         assert reason is None
 
     def test_named_httpx_connect_error_classified_as_skipped(self):
-        connect_error_cls = type(
-            "ConnectError", (Exception,), {"__module__": "httpx"}
-        )
+        connect_error_cls = type("ConnectError", (Exception,), {"__module__": "httpx"})
         exc = connect_error_cls("conn refused")
         reason = _classify_exception(exc)
         assert reason is not None
@@ -60,7 +59,7 @@ class TestRunOneFixture:
 
     def test_passes_when_pipeline_returns(self):
         pipeline_fn = lambda **k: "ok"  # noqa: E731
-        fixture = {"id": "f1", "context": {"x": 1}}
+        fixture = Fixture(id="f1", context={"x": 1}, description="Test fixture")
         result = _run_one_fixture(pipeline_fn, fixture)
         assert result.verdict == "passed"
         assert result.failure_message is None
@@ -70,7 +69,7 @@ class TestRunOneFixture:
         def pipeline_fn(**kwargs):
             raise ValueError("schema bad")
 
-        fixture = {"id": "f-fail", "context": {}}
+        fixture = Fixture(id="f-fail", context={}, description="Test fixture")
         result = _run_one_fixture(pipeline_fn, fixture)
         assert result.verdict == "failed"
         assert "ValueError" in result.failure_message
@@ -81,7 +80,7 @@ class TestRunOneFixture:
         def pipeline_fn(**kwargs):
             raise ConnectionError("ollama down")
 
-        fixture = {"id": "f-skip", "context": {}}
+        fixture = Fixture(id="f-skip", context={}, description="Test fixture")
         result = _run_one_fixture(pipeline_fn, fixture)
         assert result.verdict == "skipped"
         assert result.skipped_reason
@@ -91,7 +90,7 @@ class TestRunOneFixture:
         def pipeline_fn(**kwargs):
             time.sleep(0.05)
 
-        fixture = {"id": "f-dur", "context": {}}
+        fixture = Fixture(id="f-dur", context={}, description="Test fixture")
         result = _run_one_fixture(pipeline_fn, fixture)
         assert result.duration_seconds > 0
 
@@ -101,7 +100,11 @@ class TestRunOneFixture:
         def pipeline_fn(name, value):
             captured.append((name, value))
 
-        fixture = {"id": "f-kwargs", "context": {"name": "x", "value": 42}}
+        fixture = Fixture(
+            id="f-kwargs",
+            context={"name": "x", "value": 42},
+            description="Test fixture",
+        )
         result = _run_one_fixture(pipeline_fn, fixture)
         assert result.verdict == "passed"
         assert captured == [("x", 42)]
@@ -109,10 +112,12 @@ class TestRunOneFixture:
     def test_handles_non_dict_context_as_positional(self):
         captured = []
 
-        def pipeline_fn(arg):
-            captured.append(arg)
+        def pipeline_fn(query):
+            captured.append(query)
 
-        fixture = {"id": "f-pos", "context": "raw_input_string"}
+        fixture = Fixture(
+            id="f1", context={"query": "raw_input_string"}, description="Test fixture"
+        )
         result = _run_one_fixture(pipeline_fn, fixture)
         assert result.verdict == "passed"
         assert captured == ["raw_input_string"]
@@ -131,13 +136,11 @@ class TestRunSmokeCheck:
             lambda d: fixtures,
         )
 
-    def test_passed_runs_first_fixture_only_by_default(
-        self, monkeypatch, tmp_path
-    ):
+    def test_passed_runs_first_fixture_only_by_default(self, monkeypatch, tmp_path):
         fixtures = [
-            {"id": "f1", "context": {}},
-            {"id": "f2", "context": {}},
-            {"id": "f3", "context": {}},
+            Fixture(id="f1", context={}, description="Test fixture 1"),
+            Fixture(id="f2", context={}, description="Test fixture 2"),
+            Fixture(id="f3", context={}, description="Test fixture 3"),
         ]
         self._patch_loaders(monkeypatch, lambda **k: "ok", fixtures)
 
@@ -151,9 +154,9 @@ class TestRunSmokeCheck:
 
     def test_runs_all_when_all_fixtures_true(self, monkeypatch, tmp_path):
         fixtures = [
-            {"id": "f1", "context": {}},
-            {"id": "f2", "context": {}},
-            {"id": "f3", "context": {}},
+            Fixture(id="f1", context={}, description="Test fixture 1"),
+            Fixture(id="f2", context={}, description="Test fixture 2"),
+            Fixture(id="f3", context={}, description="Test fixture 3"),
         ]
         self._patch_loaders(monkeypatch, lambda **k: "ok", fixtures)
 
@@ -162,9 +165,7 @@ class TestRunSmokeCheck:
         assert len(result.fixtures) == 3
         assert result.overall_verdict == "passed"
 
-    def test_overall_failed_when_any_fixture_failed(
-        self, monkeypatch, tmp_path
-    ):
+    def test_overall_failed_when_any_fixture_failed(self, monkeypatch, tmp_path):
         call_count = {"n": 0}
 
         def pipeline_fn(**kwargs):
@@ -174,8 +175,8 @@ class TestRunSmokeCheck:
             return "ok"
 
         fixtures = [
-            {"id": "f1", "context": {}},
-            {"id": "f2", "context": {}},
+            Fixture(id="f1", context={}, description="Test fixture 1"),
+            Fixture(id="f2", context={}, description="Test fixture 2"),
         ]
         self._patch_loaders(monkeypatch, pipeline_fn, fixtures)
 
@@ -187,7 +188,7 @@ class TestRunSmokeCheck:
         def pipeline_fn(**kwargs):
             raise ConnectionError("backend down")
 
-        fixtures = [{"id": "f1", "context": {}}]
+        fixtures = [Fixture(id="f1", context={}, description="Test fixture 1")]
         self._patch_loaders(monkeypatch, pipeline_fn, fixtures)
 
         result = run_smoke_check(tmp_path, all_fixtures=False)
@@ -195,7 +196,7 @@ class TestRunSmokeCheck:
         assert result.overall_verdict == "skipped"
 
     def test_step_7b_report_shape(self, monkeypatch, tmp_path):
-        fixtures = [{"id": "f1", "context": {}}]
+        fixtures = [Fixture(id="f1", context={}, description="Test fixture 1")]
         self._patch_loaders(monkeypatch, lambda **k: "ok", fixtures)
 
         run_smoke_check(tmp_path, all_fixtures=False)
@@ -216,7 +217,7 @@ class TestRunSmokeCheck:
         assert "duration_seconds" in fx
 
     def test_exit_code_passed_is_zero(self, monkeypatch, tmp_path):
-        fixtures = [{"id": "f1", "context": {}}]
+        fixtures = [Fixture(id="f1", context={}, description="Test fixture 1")]
         self._patch_loaders(monkeypatch, lambda **k: "ok", fixtures)
 
         result = run_smoke_check(tmp_path, all_fixtures=False)
@@ -226,7 +227,7 @@ class TestRunSmokeCheck:
         def pipeline_fn(**kwargs):
             raise ValueError("bad")
 
-        fixtures = [{"id": "f1", "context": {}}]
+        fixtures = [Fixture(id="f1", context={}, description="Test fixture 1")]
         self._patch_loaders(monkeypatch, pipeline_fn, fixtures)
 
         result = run_smoke_check(tmp_path, all_fixtures=False)
@@ -236,7 +237,7 @@ class TestRunSmokeCheck:
         def pipeline_fn(**kwargs):
             raise ConnectionError("down")
 
-        fixtures = [{"id": "f1", "context": {}}]
+        fixtures = [Fixture(id="f1", context={}, description="Test fixture 1")]
         self._patch_loaders(monkeypatch, pipeline_fn, fixtures)
 
         result = run_smoke_check(tmp_path, all_fixtures=False)

--- a/tests/mellea_skills_compiler/toolkit/test_file_utils.py
+++ b/tests/mellea_skills_compiler/toolkit/test_file_utils.py
@@ -254,7 +254,9 @@ class TestLoadSkillPipeline:
             "    return ('canonical', user_input, doc)\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
-            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_a_helper_pkg", source)
+            pkg_dir = _make_pipeline_package(
+                Path(tmp), "synthetic_a_helper_pkg", source
+            )
             fn = load_skill_pipeline(pkg_dir)
             # The canonical entry point takes user_input by kwarg and returns the canonical marker
             assert fn.__name__ == "run_pipeline"
@@ -262,12 +264,11 @@ class TestLoadSkillPipeline:
 
     def test_falls_back_to_first_run_function_when_no_run_pipeline(self):
         """If pipeline.py only defines run_other, that's the entry point."""
-        source = (
-            "def run_assessment_method(arg):\n"
-            "    return ('only-helper', arg)\n"
-        )
+        source = "def run_assessment_method(arg):\n" "    return ('only-helper', arg)\n"
         with tempfile.TemporaryDirectory() as tmp:
-            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_no_canonical_pkg", source)
+            pkg_dir = _make_pipeline_package(
+                Path(tmp), "synthetic_no_canonical_pkg", source
+            )
             fn = load_skill_pipeline(pkg_dir)
             assert fn.__name__ == "run_assessment_method"
 
@@ -281,7 +282,9 @@ class TestLoadSkillPipeline:
             "    return ('helper', x)\n"
         )
         with tempfile.TemporaryDirectory() as tmp:
-            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_z_helper_pkg", source)
+            pkg_dir = _make_pipeline_package(
+                Path(tmp), "synthetic_z_helper_pkg", source
+            )
             fn = load_skill_pipeline(pkg_dir)
             assert fn.__name__ == "run_pipeline"
 
@@ -295,7 +298,9 @@ class TestLoadSkillPipeline:
         )
         helpers = "def run_helper(x):\n    return ('imported', x)\n"
         with tempfile.TemporaryDirectory() as tmp:
-            pkg_dir = _make_pipeline_package(Path(tmp), "synthetic_with_import_pkg", source)
+            pkg_dir = _make_pipeline_package(
+                Path(tmp), "synthetic_with_import_pkg", source
+            )
             (pkg_dir / "helpers.py").write_text(helpers)
             fn = load_skill_pipeline(pkg_dir)
             assert fn.__name__ == "run_pipeline"
@@ -308,7 +313,7 @@ class TestLoadSkillPipeline:
             pkg_dir.mkdir()
             (pkg_dir / "__init__.py").write_text("")
             # No pipeline.py
-            with pytest.raises(Exception, match="pipeline.py"):
+            with pytest.raises(Exception, match="missing_pipeline_pkg.pipeline"):
                 load_skill_pipeline(pkg_dir)
 
     def test_raises_when_no_run_function_defined(self):


### PR DESCRIPTION
# Smoke-Test Run Single Fixture Fix

## Summary
Previously, Fixture was a dict, but now it is a class. Hence, accessing it as a dict attribute will fail. This PR Improves type safety and code quality in the smoke test runner by using proper Fixture model objects instead of raw dictionaries.

## Changes
- **Type Safety Enhancement**: Updated `_run_one_fixture()` to accept `Fixture` objects instead of `Dict[str, Any]`
- **Cleaner Access Patterns**: Replaced dictionary access (`fixture.get()`, `fixture["key"]`) with direct attribute access (`fixture.id`, `fixture.context`)
- **Code Formatting**: Applied Black formatting to long conditionals for PEP 8 compliance