### PR TITLE
Update mellea[hooks] dependency version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=6.0",
-    "mellea[hooks]>=0.3.2",
+    "mellea[hooks]>=0.3.2,<=0.5.0",
     "ai-atlas-nexus[ollama]",
     "rich",
     "typer",


### PR DESCRIPTION
Restrict mellea[hooks] version to be between 0.3.2 and 0.5.0.