### PR TITLE
Update risk list format, guardian risk caching and cli profiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 tests = ["pytest", "pytest-cov", "pytest-asyncio"]
 secrets = ["detect-secrets @ git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets"]
 docs = ["zensical", "mkdocstrings-python"]
+profile = ["yappi>=1.6,<2"]
 
 [tool.pdm.version]
 source = "file"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ mellea-skills = "mellea_skills_compiler.cli:app"
 
 [tool.pdm.build]
 package-dir = "src"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/mellea_skills_compiler/certification/policy.py
+++ b/src/mellea_skills_compiler/certification/policy.py
@@ -61,7 +61,7 @@ def generate_policy_manifest(
         zero_shot_only=True,
     )
 
-    identified_risks = risk_lists.get("risks", [])
+    identified_risks = risk_lists["per_usecase"][0].get("risks", [])
     LOGGER.info(f"AI Atlas Nexus risks: {len(identified_risks)}")
 
     risks: list[NexusRisk] = []

--- a/src/mellea_skills_compiler/certification/policy.py
+++ b/src/mellea_skills_compiler/certification/policy.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from logging import Logger
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from mellea_skills_compiler.enums import (
     GovernanceTaxonomy,
@@ -61,7 +61,8 @@ def generate_policy_manifest(
         zero_shot_only=True,
     )
 
-    identified_risks = risk_lists["per_usecase"][0].get("risks", [])
+    per_usecase = risk_lists.get("per_usecase") or []
+    identified_risks = per_usecase[0].get("risks", []) if per_usecase else []
     LOGGER.info(f"AI Atlas Nexus risks: {len(identified_risks)}")
 
     risks: list[NexusRisk] = []

--- a/src/mellea_skills_compiler/cli.py
+++ b/src/mellea_skills_compiler/cli.py
@@ -1,8 +1,13 @@
+import cProfile
+import functools
+import os
+import pstats
 import signal
 import sys
+from io import StringIO
 from logging import Logger
 from pathlib import Path
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Callable, Literal, Optional, TypeVar
 
 import typer
 from typer.main import Typer
@@ -16,6 +21,40 @@ from mellea_skills_compiler.toolkit.logging import configure_logger
 
 app: Typer = typer.Typer(no_args_is_help=True)
 LOGGER: Logger = configure_logger()
+
+F = TypeVar("F", bound=Callable)
+
+
+def _profile_if_enabled(func: F) -> F:
+    """Wrap a function to profile it if MELLEA_PROFILE env var is set.
+
+    Set MELLEA_PROFILE=1 to enable cProfile profiling of the command.
+    Profiling results (top 40 functions by cumulative time) are printed
+    to stdout after the command completes.
+
+    Example:
+        MELLEA_PROFILE=1 mellea-skills-compiler compile spec.yaml
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if not os.environ.get("MELLEA_PROFILE"):
+            return func(*args, **kwargs)
+
+        pr = cProfile.Profile()
+        pr.enable()
+        try:
+            result = func(*args, **kwargs)
+        finally:
+            pr.disable()
+            stream = StringIO()
+            stats = pstats.Stats(pr, stream=stream).sort_stats("cumulative")
+            stats.print_stats(40)
+            print("\n" + "=" * 80)
+            print("PROFILING RESULTS (MELLEA_PROFILE=1)")
+            print("=" * 80)
+            print(stream.getvalue())
+        return result
+    return wrapper
 
 
 def signal_handler(sig, frame):
@@ -35,6 +74,9 @@ def main() -> None:
 
     Transform AI agent skill specifications into certified, governed pipelines
     with comprehensive risk analysis and compliance reporting.
+
+    Environment variables:
+      MELLEA_PROFILE=1  Enable cProfile profiling for any command (outputs top 40 functions by cumulative time).
     """
 
 
@@ -42,6 +84,7 @@ def main() -> None:
     help="Melleafy Compile: Decompose an Agent Spec into Mellea Code",
     epilog="Compile Mellea skill specification into a Mellea pipeline. Use --backend to select compilation backend [claude, bob].",
 )
+@_profile_if_enabled
 def compile(
     ctx: typer.Context,
     spec_path: Annotated[
@@ -184,6 +227,7 @@ def validate(
 
 
 @app.command(help="Run Mellea Skill Pipeline")
+@_profile_if_enabled
 def run(
     ctx: typer.Context,
     pipeline_dir: Annotated[
@@ -320,6 +364,7 @@ def ingest(
 
 
 @app.command(help="Run Full Certification Pipeline for Mellea skill")
+@_profile_if_enabled
 def certify(
     ctx: typer.Context,
     pipeline_dir: Annotated[

--- a/src/mellea_skills_compiler/cli.py
+++ b/src/mellea_skills_compiler/cli.py
@@ -38,7 +38,7 @@ def main() -> None:
     with comprehensive risk analysis and compliance reporting.
 
     Environment variables:
-      MELLEA_PROFILE=1  Enable cProfile profiling for any command (outputs top 40 functions by cumulative time).
+      MELLEA_PROFILE=1  Enable profiling for compile/run/certify (captures worker threads; outputs per-thread summary and top 40 functions by total time).
     """
 
 

--- a/src/mellea_skills_compiler/cli.py
+++ b/src/mellea_skills_compiler/cli.py
@@ -1,13 +1,8 @@
-import cProfile
-import functools
-import os
-import pstats
 import signal
 import sys
-from io import StringIO
 from logging import Logger
 from pathlib import Path
-from typing import Annotated, Callable, Literal, Optional, TypeVar
+from typing import Annotated, Literal, Optional
 
 import typer
 from typer.main import Typer
@@ -17,44 +12,11 @@ from mellea_skills_compiler.enums import (
     InferenceEngineType,
 )
 from mellea_skills_compiler.toolkit.logging import configure_logger
+from mellea_skills_compiler.toolkit.profiling import profile_if_enabled
 
 
 app: Typer = typer.Typer(no_args_is_help=True)
 LOGGER: Logger = configure_logger()
-
-F = TypeVar("F", bound=Callable)
-
-
-def _profile_if_enabled(func: F) -> F:
-    """Wrap a function to profile it if MELLEA_PROFILE env var is set.
-
-    Set MELLEA_PROFILE=1 to enable cProfile profiling of the command.
-    Profiling results (top 40 functions by cumulative time) are printed
-    to stdout after the command completes.
-
-    Example:
-        MELLEA_PROFILE=1 mellea-skills compile spec.yaml
-    """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if not os.environ.get("MELLEA_PROFILE"):
-            return func(*args, **kwargs)
-
-        pr = cProfile.Profile()
-        pr.enable()
-        try:
-            result = func(*args, **kwargs)
-        finally:
-            pr.disable()
-            stream = StringIO()
-            stats = pstats.Stats(pr, stream=stream).sort_stats("cumulative")
-            stats.print_stats(40)
-            print("\n" + "=" * 80)
-            print("PROFILING RESULTS (MELLEA_PROFILE=1)")
-            print("=" * 80)
-            print(stream.getvalue())
-        return result
-    return wrapper
 
 
 def signal_handler(sig, frame):
@@ -84,7 +46,7 @@ def main() -> None:
     help="Melleafy Compile: Decompose an Agent Spec into Mellea Code",
     epilog="Compile Mellea skill specification into a Mellea pipeline. Use --backend to select compilation backend [claude, bob].",
 )
-@_profile_if_enabled
+@profile_if_enabled
 def compile(
     ctx: typer.Context,
     spec_path: Annotated[
@@ -227,7 +189,7 @@ def validate(
 
 
 @app.command(help="Run Mellea Skill Pipeline")
-@_profile_if_enabled
+@profile_if_enabled
 def run(
     ctx: typer.Context,
     pipeline_dir: Annotated[
@@ -364,7 +326,7 @@ def ingest(
 
 
 @app.command(help="Run Full Certification Pipeline for Mellea skill")
-@_profile_if_enabled
+@profile_if_enabled
 def certify(
     ctx: typer.Context,
     pipeline_dir: Annotated[

--- a/src/mellea_skills_compiler/cli.py
+++ b/src/mellea_skills_compiler/cli.py
@@ -33,7 +33,7 @@ def _profile_if_enabled(func: F) -> F:
     to stdout after the command completes.
 
     Example:
-        MELLEA_PROFILE=1 mellea-skills-compiler compile spec.yaml
+        MELLEA_PROFILE=1 mellea-skills compile spec.yaml
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/src/mellea_skills_compiler/plugins/audit.py
+++ b/src/mellea_skills_compiler/plugins/audit.py
@@ -85,13 +85,18 @@ class AuditTrailPlugin(
             verdicts = self.guardian_plugin.verdicts_by_generation_id.get(
                 generation_id, []
             )
-            if verdicts:
-                return list(verdicts)
-        else:
-            LOGGER.debug(
-                "audit trail: falling back to positional verdict lookup "
-                "(no generation_id on payload). Expected on <0.7 mellea only."
-            )
+            if not verdicts:
+                LOGGER.warning(
+                    "audit trail: no verdicts indexed for generation_id=%s — "
+                    "returning empty rather than falling back to positional "
+                    "lookup.",
+                    generation_id,
+                )
+            return list(verdicts)
+        LOGGER.debug(
+            "audit trail: falling back to positional verdict lookup "
+            "(no generation_id on payload). Expected on <0.7 mellea only."
+        )
         # Legacy fallback for payloads without a generation_id.
         n = len(getattr(self.guardian_plugin, "risks", []) or []) or 1
         return list(self.guardian_plugin.all_verdicts[-n:])

--- a/src/mellea_skills_compiler/plugins/guardian.py
+++ b/src/mellea_skills_compiler/plugins/guardian.py
@@ -22,8 +22,11 @@ Usage (enforce mode — blocks on risk):
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
-from copy import deepcopy
+import threading
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
 from mellea.core.requirement import Requirement
@@ -39,8 +42,7 @@ from mellea_skills_compiler.enums import (
     HookStage,
     InferenceEngineType,
 )
-from mellea_skills_compiler.inference import InferenceService
-from mellea_skills_compiler.models import GuardianVerdict, NexusRisk, PolicyManifest
+from mellea_skills_compiler.models import GuardianVerdict, NexusRisk
 from mellea_skills_compiler.plugins import BasePlugin
 from mellea_skills_compiler.toolkit.logging import configure_logger
 
@@ -48,6 +50,39 @@ from mellea_skills_compiler.toolkit.logging import configure_logger
 LOGGER = configure_logger()
 console = Console()
 GUARDIAN_RETRY_ATTEMPTS = 2
+GUARDIAN_MAX_CONCURRENCY = 4
+GUARDIAN_CACHE_MAXSIZE = 512
+
+_GUARDIAN_SEMAPHORE = threading.Semaphore(GUARDIAN_MAX_CONCURRENCY)
+_VERDICT_CACHE: OrderedDict[tuple, GuardianVerdict] = OrderedDict()
+_CACHE_LOCK = threading.Lock()
+
+
+def _blocking_chat(inference_engine, messages_batch):
+    with _GUARDIAN_SEMAPHORE:
+        return inference_engine.chat(messages_batch, verbose=False)
+
+
+def _cache_key(risk_name: str, judged_text: str, stage: HookStage) -> tuple:
+    digest = hashlib.sha256(judged_text.encode("utf-8")).hexdigest()
+    return (risk_name, digest, stage)
+
+
+def _cache_get(risk_name: str, judged_text: str, stage: HookStage) -> Optional[GuardianVerdict]:
+    key = _cache_key(risk_name, judged_text, stage)
+    with _CACHE_LOCK:
+        return _VERDICT_CACHE.get(key)
+
+
+def _cache_set(risk_name: str, judged_text: str, stage: HookStage, verdict: GuardianVerdict) -> None:
+    key = _cache_key(risk_name, judged_text, stage)
+    with _CACHE_LOCK:
+        if key in _VERDICT_CACHE:
+            _VERDICT_CACHE.move_to_end(key)
+        else:
+            if len(_VERDICT_CACHE) >= GUARDIAN_CACHE_MAXSIZE:
+                _VERDICT_CACHE.popitem(last=False)
+            _VERDICT_CACHE[key] = verdict
 
 
 def _parse_guardian_score(text: str) -> str:
@@ -62,20 +97,45 @@ def _parse_guardian_score(text: str) -> str:
     return GuardianScore.FAILED
 
 
-def _call_guardian(
+async def _retry_one(risk_name: str, messages: List, inference_engine, hook_stage: HookStage) -> GuardianVerdict:
+    """Retry a single failed verdict concurrently."""
+    preview_source = messages[-1]["content"] if messages[-1]["role"] == "assistant" else messages[-1]["content"] if messages[-1]["role"] == "user" else ""
+    preview = preview_source.replace("\n", " ")[0:90]
+    console.print(
+        f'[white]  risk={messages[0]["content"]}\n  preview={preview}[/]'
+    )
+
+    try:
+        raw_prediction = (await asyncio.to_thread(_blocking_chat, inference_engine, [messages]))[0].prediction
+        label = _parse_guardian_score(raw_prediction)
+    except Exception as e:
+        LOGGER.warning("Guardian call failed for risk=%s: %s", risk_name, e)
+        label = GuardianScore.ERROR
+        raw_prediction = ""
+
+    return GuardianVerdict(
+        risk=risk_name,
+        label=label,
+        raw_output=raw_prediction,
+        hook_stage=hook_stage,
+    )
+
+
+async def _call_guardian(
     hook_stage: HookStage,
     risks: List[NexusRisk],
     input_text: str,
     inference_engine,
     assistant_text: Optional[str] = None,
+    name_prefix: str = "",
 ) -> List[GuardianVerdict]:
-    """Synchronous call to Guardian.
+    """Async call to Guardian with caching and concurrent retries.
 
     Guardian expects a chat with the user turn (+ optional assistant turn)
     and a system prompt specifying the risk to evaluate.
 
     The ``risk`` parameter is the Guardian system prompt content:
-      - For native risks (from Nexus ``tag`` field): a bare risk name like
+      - For native risks (from Nexus ``tag`` field): a risk name like
         ``"harm"``, ``"social_bias"``, ``"jailbreak"`` — Guardian uses its
         calibrated assessment path for these.
       - For custom criteria (no Nexus ``tag``): description text
@@ -90,88 +150,108 @@ def _call_guardian(
 
     Guardian response format: ``<score>yes</score>`` (risk detected) or
     ``<score>no</score>`` (safe).
+
+    The name_prefix is prepended to verdict.risk for tool-namespacing (e.g. "tool:").
+    Cache keys use the risk.name so tool-prefixed and unprefixed verdicts
+    for the same text are deduplicated.
     """
 
-    # Extract risk names and their prompts
-    risk_names = [r.name for r in risks]
-    guardian_prompts = [r.guardian_prompt for r in risks]
+    # Construct judged text for caching
+    judged_text = input_text + "\x00" + (assistant_text or "")
 
-    # Create guardian message prompts
-    all_messages = []
-    for guardian_prompt in guardian_prompts:
-        messages = [{"role": "system", "content": guardian_prompt}]
-        if input_text:
-            messages.append({"role": "user", "content": input_text})
-        if assistant_text:
-            messages.append({"role": "assistant", "content": assistant_text})
-        all_messages.append(messages)
+    # Check cache and separate cache hits from misses
+    cached_verdicts = {}
+    risks_to_query = []
+    messages_to_query = []
 
-    try:
-        # Batch inferencing guardian risks
-        raw_predictions = [
-            raw_prediction.prediction
-            for raw_prediction in inference_engine.chat(all_messages, verbose=False)
-        ]
+    for risk in risks:
+        cached = _cache_get(risk.name, judged_text, hook_stage)
+        if cached:
+            cached_verdicts[risk.name] = cached
+        else:
+            risks_to_query.append(risk)
+            messages = [{"role": "system", "content": risk.guardian_prompt}]
+            if input_text:
+                messages.append({"role": "user", "content": input_text})
+            if assistant_text:
+                messages.append({"role": "assistant", "content": assistant_text})
+            messages_to_query.append(messages)
 
-    except Exception as e:
-        LOGGER.warning("Guardian call failed for risks=%s: %s", risk_names, e)
-        return [
-            GuardianVerdict(
-                risk=risk.name,
-                label=GuardianScore.ERROR,
-                raw_output="",
-            )
-            for risk in risks
-        ]
-
-    # Create Guardian Verdict
-    verdicts = []
-    for risk_name, messages, raw_prediction in zip(
-        risk_names, all_messages, raw_predictions
-    ):
-        label = _parse_guardian_score(raw_prediction)
-
-        # retry failed guardian call
-        if label == GuardianScore.FAILED:
-            attempt = 1
-            while attempt <= GUARDIAN_RETRY_ATTEMPTS:
-                LOGGER.warning(
-                    f"Retrying failed guardian assessment - {risk_name}...attempt: {attempt}"
+    # Batch query for cache misses
+    verdicts_by_name = dict(cached_verdicts)
+    if risks_to_query:
+        try:
+            raw_predictions = [
+                raw_prediction.prediction
+                for raw_prediction in await asyncio.to_thread(_blocking_chat, inference_engine, messages_to_query)
+            ]
+        except Exception as e:
+            LOGGER.warning("Guardian call failed for risks=%s: %s", [r.name for r in risks_to_query], e)
+            for risk in risks_to_query:
+                verdict = GuardianVerdict(
+                    risk=risk.name,
+                    label=GuardianScore.ERROR,
+                    raw_output="",
+                    hook_stage=hook_stage,
                 )
-                preview_source = assistant_text if assistant_text else input_text
-                preview = preview_source.replace("\n", " ")[0:90]
-                console.print(
-                    f'[white]  risk={messages[0]["content"]}\n  label={label}\n  preview={preview}[/]'
+                verdicts_by_name[risk.name] = verdict
+            raw_predictions = [GuardianScore.ERROR] * len(risks_to_query)
+
+        # Parse predictions and collect failures for retry
+        failed_indices = []
+        for idx, (risk, messages, raw_prediction) in enumerate(zip(risks_to_query, messages_to_query, raw_predictions)):
+            label = _parse_guardian_score(raw_prediction)
+
+            if label == GuardianScore.FAILED:
+                failed_indices.append(idx)
+            else:
+                verdict = GuardianVerdict(
+                    risk=risk.name,
+                    label=label,
+                    raw_output=raw_prediction,
+                    hook_stage=hook_stage,
                 )
+                verdicts_by_name[risk.name] = verdict
+                if label in [GuardianScore.YES, GuardianScore.NO]:
+                    _cache_set(risk.name, judged_text, hook_stage, verdict)
 
-                try:
-                    raw_prediction = inference_engine.chat([messages], verbose=False)[
-                        0
-                    ].prediction
-                    label = _parse_guardian_score(raw_prediction)
-                except Exception as e:
-                    LOGGER.warning("Guardian call failed for risk=%s: %s", risk_name, e)
-                    label = GuardianScore.ERROR
-                    raw_prediction = ""
+        # Concurrent retries for failed predictions
+        if failed_indices:
+            retry_tasks = [
+                _retry_one(risks_to_query[idx].name, messages_to_query[idx], inference_engine, hook_stage)
+                for idx in failed_indices
+            ]
+            latest_by_idx = dict(zip(failed_indices, await asyncio.gather(*retry_tasks)))
 
-                if label not in [GuardianScore.FAILED, GuardianScore.ERROR]:
+            for attempt in range(GUARDIAN_RETRY_ATTEMPTS - 1):
+                still_failed = [idx for idx, v in latest_by_idx.items() if v.label == GuardianScore.FAILED]
+                if not still_failed:
                     break
+                retry_tasks = []
+                for idx in still_failed:
+                    LOGGER.warning(f"Retrying failed guardian assessment - {risks_to_query[idx].name}...attempt: {attempt + 2}")
+                    retry_tasks.append(_retry_one(risks_to_query[idx].name, messages_to_query[idx], inference_engine, hook_stage))
+                for idx, v in zip(still_failed, await asyncio.gather(*retry_tasks)):
+                    latest_by_idx[idx] = v
 
-                attempt += 1
+            for verdict in latest_by_idx.values():
+                verdicts_by_name[verdict.risk] = verdict
+                if verdict.label in [GuardianScore.YES, GuardianScore.NO]:
+                    _cache_set(verdict.risk, judged_text, hook_stage, verdict)
 
-        verdicts.append(
-            GuardianVerdict(
-                risk=risk_name,
-                label=label,
-                raw_output=raw_prediction,
-                hook_stage=hook_stage,
-            )
+    # Apply name_prefix and return in original risk order
+    return [
+        GuardianVerdict(
+            risk=f"{name_prefix}{verdicts_by_name[r.name].risk}",
+            label=verdicts_by_name[r.name].label,
+            raw_output=verdicts_by_name[r.name].raw_output,
+            hook_stage=verdicts_by_name[r.name].hook_stage,
         )
+        for r in risks
+    ]
 
-    return verdicts
 
-
-def _run_guardian_post_checks(
+async def _run_guardian_post_checks(
     payload: Any, risks: List[NexusRisk], inference_engine: str
 ) -> List[GuardianVerdict]:
     """Shared logic: run Guardian checks and return (verdicts, flagged_labels)."""
@@ -199,7 +279,7 @@ def _run_guardian_post_checks(
     else:
         input_text = str(prompt) if prompt else ""
 
-    verdicts: List[GuardianVerdict] = _call_guardian(
+    verdicts: List[GuardianVerdict] = await _call_guardian(
         HookStage.POST, risks, input_text, inference_engine, assistant_text
     )
     for verdict in verdicts:
@@ -210,7 +290,7 @@ def _run_guardian_post_checks(
     return verdicts
 
 
-def _run_guardian_pre_checks(
+async def _run_guardian_pre_checks(
     payload: Any, risks: List[NexusRisk], inference_engine: str
 ) -> List[GuardianVerdict]:
     """Pre-generation check: assess the input prompt before LLM generation.
@@ -251,7 +331,7 @@ def _run_guardian_pre_checks(
         return []
 
     assistant_text = None
-    verdicts: List[GuardianVerdict] = _call_guardian(
+    verdicts: List[GuardianVerdict] = await _call_guardian(
         HookStage.PRE, risks, input_text, inference_engine, assistant_text
     )
     for verdict in verdicts:
@@ -339,13 +419,13 @@ class GuardianAuditPlugin(
     @hook(HookType.GENERATION_PRE_CALL, mode=PluginMode.AUDIT)
     async def check_input(self, payload: Any, ctx: Any) -> None:
         """Pre-generation: assess input prompt for risks (observe-only)."""
-        verdicts = _run_guardian_pre_checks(payload, self.risks, self.inference_engine)
+        verdicts = await _run_guardian_pre_checks(payload, self.risks, self.inference_engine)
         self.all_verdicts.extend(verdicts)
 
     @hook(HookType.GENERATION_POST_CALL, mode=PluginMode.AUDIT)
     async def check_output(self, payload: Any, ctx: Any) -> None:
         """Post-generation: assess LLM output for risks (observe-only)."""
-        verdicts = _run_guardian_post_checks(payload, self.risks, self.inference_engine)
+        verdicts = await _run_guardian_post_checks(payload, self.risks, self.inference_engine)
         self.all_verdicts.extend(verdicts)
 
     @hook(HookType.TOOL_PRE_INVOKE, mode=PluginMode.AUDIT)
@@ -381,20 +461,14 @@ class GuardianAuditPlugin(
         )
 
         if not (not tool_output or not payload.success):
-
-            tool_risks = []
-            for risk in self.risks:
-                tool_risk = deepcopy(risk)
-                tool_risk.name = f"tool:{tool_risk.name}"
-                tool_risks.append(tool_risk)
-
             # Run Guardian checks on the tool output (treat as assistant text)
-            verdicts: list[GuardianVerdict] = _call_guardian(
+            verdicts: list[GuardianVerdict] = await _call_guardian(
                 HookStage.TOOLS_POST,
-                tool_risks,
-                user_text=f"Tool {tool_name} was called",
+                self.risks,
+                input_text=f"Tool {tool_name} was called",
                 assistant_text=tool_output[:2000],
                 inference_engine=self.inference_engine,
+                name_prefix="tool:",
             )
             self.all_verdicts.extend(verdicts)
 
@@ -430,7 +504,7 @@ class GuardianEnforcePlugin(
     @hook(HookType.GENERATION_PRE_CALL, mode=PluginMode.SEQUENTIAL)
     async def enforce_input(self, payload: Any, ctx: Any) -> Any:
         """Pre-generation: block if input prompt has risks."""
-        verdicts: List[GuardianVerdict] = _run_guardian_pre_checks(
+        verdicts: List[GuardianVerdict] = await _run_guardian_pre_checks(
             payload, self.risks, self.inference_engine
         )
         self.all_verdicts.extend(verdicts)
@@ -468,7 +542,7 @@ class GuardianEnforcePlugin(
     @hook(HookType.GENERATION_POST_CALL, mode=PluginMode.SEQUENTIAL)
     async def enforce_output(self, payload: Any, ctx: Any) -> Any:
         """Post-generation: block if LLM output has risks."""
-        verdicts = _run_guardian_post_checks(payload, self.risks, self.inference_engine)
+        verdicts = await _run_guardian_post_checks(payload, self.risks, self.inference_engine)
         self.all_verdicts.extend(verdicts)
 
         flagged = [v.risk for v in verdicts if v.label == GuardianScore.YES]
@@ -508,18 +582,13 @@ class GuardianEnforcePlugin(
         tool_name = getattr(tool_call, "name", "unknown")
         args = getattr(tool_call, "args", {})
 
-        tool_risks = []
-        for risk in self.risks:
-            tool_risk = deepcopy(risk)
-            tool_risk.name = f"tool:{tool_risk.name}"
-            tool_risks.append(tool_risk)
-
         # Run Guardian checks on tool input
-        verdicts: list[GuardianVerdict] = _call_guardian(
+        verdicts: list[GuardianVerdict] = await _call_guardian(
             HookStage.TOOLS_PRE,
-            tool_risks,
+            self.risks,
             input_text=f"Tool {tool_name} was called with arguments: {json.dumps(args, indent=2)}",
             inference_engine=self.inference_engine,
+            name_prefix="tool:",
         )
         self.all_verdicts.extend(verdicts)
 
@@ -570,19 +639,14 @@ class GuardianEnforcePlugin(
         if not tool_output or not payload.success:
             return None
 
-        tool_risks = []
-        for risk in self.risks:
-            tool_risk = deepcopy(risk)
-            tool_risk.name = f"tool:{tool_risk.name}"
-            tool_risks.append(tool_risk)
-
         # Run Guardian checks on tool output
-        verdicts: list[GuardianVerdict] = _call_guardian(
+        verdicts: list[GuardianVerdict] = await _call_guardian(
             HookStage.TOOLS_POST,
-            tool_risks,
+            self.risks,
             input_text=f"Tool {tool_name} was called",
             assistant_text=tool_output[:2000],
             inference_engine=self.inference_engine,
+            name_prefix="tool:",
         )
         self.all_verdicts.extend(verdicts)
 

--- a/src/mellea_skills_compiler/plugins/guardian.py
+++ b/src/mellea_skills_compiler/plugins/guardian.py
@@ -250,9 +250,24 @@ async def _call_guardian(
         for r in risks
     ]
 
+def _get_thunk_action(model_output: Any) -> Any:
+    """Return the originating action of a ``ModelOutputThunk``, or ``None``.
+
+    On mellea 0.7+ the action lives at ``thunk._call.action`` (see
+    ``_CallInfo`` in ``mellea/core/base.py``); on <0.7 it was on
+    ``thunk._action``. Both paths are private, but the dual accessor lets
+    us survive the rename without wire-level knowledge of which mellea we
+    are running against. This is a fallback for the id-correlation path
+    below — if ``payload.generation_id`` is populated (0.7+) we prefer
+    that.
+    """
+    call = getattr(model_output, "_call", None)
+    if call is not None:
+        return getattr(call, "action", None)
+    return getattr(model_output, "_action", None)
 
 async def _run_guardian_post_checks(
-    payload: Any, risks: List[NexusRisk], inference_engine: str
+    plugin, payload: Any, risks: List[NexusRisk], inference_engine: str
 ) -> List[GuardianVerdict]:
     """Shared logic: run Guardian checks and return (verdicts, flagged_labels).
 
@@ -323,7 +338,7 @@ async def _run_guardian_post_checks(
 
 
 async def _run_guardian_pre_checks(
-    payload: Any, risks: List[NexusRisk], inference_engine: str
+    plugin, payload: Any, risks: List[NexusRisk], inference_engine: str
 ) -> List[GuardianVerdict]:
     """Pre-generation check: assess the input prompt before LLM generation.
 
@@ -487,13 +502,13 @@ class GuardianAuditPlugin(
     @hook(HookType.GENERATION_PRE_CALL, mode=PluginMode.AUDIT)
     async def check_input(self, payload: Any, ctx: Any) -> None:
         """Pre-generation: assess input prompt for risks (observe-only)."""
-        verdicts = await _run_guardian_pre_checks(payload, self.risks, self.inference_engine)
+        verdicts = await _run_guardian_pre_checks(self, payload, self.risks, self.inference_engine)
         self.all_verdicts.extend(verdicts)
 
     @hook(HookType.GENERATION_POST_CALL, mode=PluginMode.AUDIT)
     async def check_output(self, payload: Any, ctx: Any) -> None:
         """Post-generation: assess LLM output for risks (observe-only)."""
-        verdicts = await _run_guardian_post_checks(payload, self.risks, self.inference_engine)
+        verdicts = await _run_guardian_post_checks(self, payload, self.risks, self.inference_engine)
         self.all_verdicts.extend(verdicts)
 
     @hook(HookType.TOOL_PRE_INVOKE, mode=PluginMode.AUDIT)
@@ -554,6 +569,66 @@ class GuardianAuditPlugin(
                 )
                 console.print()
 
+    @hook(HookType.GENERATION_ERROR, mode=PluginMode.AUDIT)
+    async def check_error(self, payload: Any, ctx: Any) -> None:
+        """Generation error: record an ERROR verdict per risk (observe-only)."""
+        generation_id = getattr(payload, "generation_id", None)
+        verdicts = [
+            GuardianVerdict(
+                risk=risk.name,
+                label=GuardianScore.ERROR,
+                raw_output=str(getattr(payload, "error", "")),
+                hook_stage=HookStage.POST,
+            )
+            for risk in self.risks
+        ]
+        self._record_verdicts(verdicts, generation_id)
+
+    @hook(HookType.GENERATION_BATCH_PRE_CALL, mode=PluginMode.AUDIT)
+    async def check_batch_input(self, payload: Any, ctx: Any) -> None:
+        """Pre-batch generation: observed only."""
+        return None
+
+    @hook(HookType.GENERATION_BATCH_POST_CALL, mode=PluginMode.AUDIT)
+    async def check_batch_output(self, payload: Any, ctx: Any) -> None:
+        """Post-batch generation: assess each item and record verdicts (observe-only)."""
+        model_outputs = getattr(payload, "model_outputs", None) or []
+        generation_ids = getattr(payload, "generation_ids", None) or [None] * len(
+            model_outputs
+        )
+        prompts = getattr(payload, "prompts", None) or [""] * len(model_outputs)
+        for model_output, gen_id, prompt in zip(model_outputs, generation_ids, prompts):
+            if model_output is None:
+                continue
+            assistant_text = getattr(model_output, "value", None)
+            if assistant_text is None or assistant_text == "":
+                continue
+            input_text = str(prompt) if prompt else ""
+            verdicts = await _call_guardian(
+                HookStage.POST,
+                self.risks,
+                input_text,
+                self.inference_engine,
+                assistant_text,
+            )
+            self._record_verdicts(verdicts, gen_id)
+
+    @hook(HookType.GENERATION_BATCH_ERROR, mode=PluginMode.AUDIT)
+    async def check_batch_error(self, payload: Any, ctx: Any) -> None:
+        """Batch generation error: record ERROR verdicts (observe-only)."""
+        generation_ids = getattr(payload, "generation_ids", None) or [None]
+        for gen_id in generation_ids:
+            verdicts = [
+                GuardianVerdict(
+                    risk=risk.name,
+                    label=GuardianScore.ERROR,
+                    raw_output=str(getattr(payload, "error", "")),
+                    hook_stage=HookStage.POST,
+                )
+                for risk in self.risks
+            ]
+            self._record_verdicts(verdicts, gen_id)
+
 
 class GuardianEnforcePlugin(
     GuardianPlugin, Plugin, name="granite-guardian-enforce", priority=40
@@ -578,7 +653,7 @@ class GuardianEnforcePlugin(
     async def enforce_input(self, payload: Any, ctx: Any) -> Any:
         """Pre-generation: block if input prompt has risks."""
         verdicts: List[GuardianVerdict] = await _run_guardian_pre_checks(
-            payload, self.risks, self.inference_engine
+            self, payload, self.risks, self.inference_engine
         )
         self._record_verdicts(verdicts, getattr(payload, "generation_id", None))
 
@@ -615,7 +690,7 @@ class GuardianEnforcePlugin(
     @hook(HookType.GENERATION_POST_CALL, mode=PluginMode.SEQUENTIAL)
     async def enforce_output(self, payload: Any, ctx: Any) -> Any:
         """Post-generation: block if LLM output has risks."""
-        verdicts = await _run_guardian_post_checks(payload, self.risks, self.inference_engine)
+        verdicts = await _run_guardian_post_checks(self, payload, self.risks, self.inference_engine)
         self.all_verdicts.extend(verdicts)
 
         flagged = [v.risk for v in verdicts if v.label == GuardianScore.YES]
@@ -817,7 +892,7 @@ class GuardianEnforcePlugin(
             if assistant_text is None or assistant_text == "":
                 continue
             input_text = str(prompt) if prompt else ""
-            verdicts = _call_guardian(
+            verdicts = await _call_guardian(
                 HookStage.POST,
                 self.risks,
                 input_text,

--- a/src/mellea_skills_compiler/plugins/guardian.py
+++ b/src/mellea_skills_compiler/plugins/guardian.py
@@ -49,16 +49,9 @@ from mellea_skills_compiler.toolkit.logging import configure_logger
 LOGGER = configure_logger()
 console = Console()
 GUARDIAN_RETRY_ATTEMPTS = 2
-GUARDIAN_MAX_CONCURRENCY = 4
 GUARDIAN_CACHE_MAXSIZE = 512
 
-_GUARDIAN_SEMAPHORE = threading.Semaphore(GUARDIAN_MAX_CONCURRENCY)
 _VERDICT_CACHE = LRUCache(maxsize=GUARDIAN_CACHE_MAXSIZE)
-
-
-def _blocking_chat(inference_engine, messages_batch):
-    with _GUARDIAN_SEMAPHORE:
-        return inference_engine.chat(messages_batch, verbose=False)
 
 
 def _cache_key(risk_name: str, judged_text: str, stage: HookStage) -> tuple:
@@ -78,28 +71,42 @@ def _parse_guardian_score(text: str) -> str:
     return GuardianScore.FAILED
 
 
-async def _retry_one(risk_name: str, messages: List, inference_engine, hook_stage: HookStage) -> GuardianVerdict:
-    """Retry a single failed verdict concurrently."""
-    preview_source = messages[-1]["content"] if messages[-1]["role"] == "assistant" else messages[-1]["content"] if messages[-1]["role"] == "user" else ""
-    preview = preview_source.replace("\n", " ")[0:90]
-    console.print(
-        f'[white]  risk={messages[0]["content"]}\n  preview={preview}[/]'
-    )
+async def _query_batch(
+    risks: List[NexusRisk],
+    messages_list: List[List[Dict[str, str]]],
+    inference_engine,
+    hook_stage: HookStage,
+) -> Dict[str, GuardianVerdict]:
+    """Run one batched Guardian call for ``risks``.
 
+    Nexus's ``inference_engine.chat()`` already has a concurrent batch API
+    so this is a single call regardless of how many risks are in the batch.
+
+    ERROR /FAILED are treated as retryable.
+    """
     try:
-        raw_prediction = (await asyncio.to_thread(_blocking_chat, inference_engine, [messages]))[0].prediction
-        label = _parse_guardian_score(raw_prediction)
+        raw_predictions = [
+            prediction.prediction
+            for prediction in await asyncio.to_thread(inference_engine.chat, messages_list, verbose=False)
+        ]
     except Exception as e:
-        LOGGER.warning("Guardian call failed for risk=%s: %s", risk_name, e)
-        label = GuardianScore.ERROR
-        raw_prediction = ""
+        LOGGER.warning("Guardian call failed for risks=%s: %s", [r.name for r in risks], e)
+        return {
+            risk.name: GuardianVerdict(
+                risk=risk.name, label=GuardianScore.ERROR, raw_output="", hook_stage=hook_stage
+            )
+            for risk in risks
+        }
 
-    return GuardianVerdict(
-        risk=risk_name,
-        label=label,
-        raw_output=raw_prediction,
-        hook_stage=hook_stage,
-    )
+    return {
+        risk.name: GuardianVerdict(
+            risk=risk.name,
+            label=_parse_guardian_score(raw_prediction),
+            raw_output=raw_prediction,
+            hook_stage=hook_stage,
+        )
+        for risk, raw_prediction in zip(risks, raw_predictions)
+    }
 
 
 async def _call_guardian(
@@ -161,66 +168,40 @@ async def _call_guardian(
     # Batch query for cache misses
     verdicts_by_name = dict(cached_verdicts)
     if risks_to_query:
-        try:
-            raw_predictions = [
-                raw_prediction.prediction
-                for raw_prediction in await asyncio.to_thread(_blocking_chat, inference_engine, messages_to_query)
-            ]
-        except Exception as e:
-            LOGGER.warning("Guardian call failed for risks=%s: %s", [r.name for r in risks_to_query], e)
-            for risk in risks_to_query:
-                verdict = GuardianVerdict(
-                    risk=risk.name,
-                    label=GuardianScore.ERROR,
-                    raw_output="",
-                    hook_stage=hook_stage,
-                )
-                verdicts_by_name[risk.name] = verdict
-            raw_predictions = [GuardianScore.ERROR] * len(risks_to_query)
+        # Initial batched query, do one call for all cache misses
+        verdicts = await _query_batch(risks_to_query, messages_to_query, inference_engine, hook_stage)
+        verdicts_by_name.update(verdicts)
 
-        # Parse predictions and collect failures for retry
-        failed_indices = []
-        for idx, (risk, messages, raw_prediction) in enumerate(zip(risks_to_query, messages_to_query, raw_predictions)):
-            label = _parse_guardian_score(raw_prediction)
+        failed_by_idx = {
+            idx: risk
+            for idx, risk in enumerate(risks_to_query)
+            if verdicts[risk.name].label == GuardianScore.FAILED
+        }
 
-            if label == GuardianScore.FAILED:
-                failed_indices.append(idx)
-            else:
-                verdict = GuardianVerdict(
-                    risk=risk.name,
-                    label=label,
-                    raw_output=raw_prediction,
-                    hook_stage=hook_stage,
-                )
-                verdicts_by_name[risk.name] = verdict
-                if label in [GuardianScore.YES, GuardianScore.NO]:
-                    _VERDICT_CACHE.set(_cache_key(risk.name, judged_text, hook_stage), verdict)
+        for attempt in range(GUARDIAN_RETRY_ATTEMPTS - 1):
+            if not failed_by_idx:
+                break
 
-        # Concurrent retries for failed predictions
-        if failed_indices:
-            retry_tasks = [
-                _retry_one(risks_to_query[idx].name, messages_to_query[idx], inference_engine, hook_stage)
-                for idx in failed_indices
-            ]
-            latest_by_idx = dict(zip(failed_indices, await asyncio.gather(*retry_tasks)))
+            for risk in failed_by_idx.values():
+                LOGGER.warning(f"Retrying failed guardian assessment - {risk.name}...attempt: {attempt + 2}")
 
-            for attempt in range(GUARDIAN_RETRY_ATTEMPTS - 1):
-                still_failed = [idx for idx, v in latest_by_idx.items() if v.label == GuardianScore.FAILED]
-                if not still_failed:
-                    break
-                retry_tasks = []
-                for idx in still_failed:
-                    LOGGER.warning(f"Retrying failed guardian assessment - {risks_to_query[idx].name}...attempt: {attempt + 2}")
-                    retry_tasks.append(_retry_one(risks_to_query[idx].name, messages_to_query[idx], inference_engine, hook_stage))
-                for idx, v in zip(still_failed, await asyncio.gather(*retry_tasks)):
-                    latest_by_idx[idx] = v
+            # Build messages for failed risks only
+            failed_risks = [failed_by_idx[idx] for idx in sorted(failed_by_idx.keys())]
+            failed_messages = [messages_to_query[idx] for idx in sorted(failed_by_idx.keys())]
 
-            for verdict in latest_by_idx.values():
-                verdicts_by_name[verdict.risk] = verdict
-                if verdict.label in [GuardianScore.YES, GuardianScore.NO]:
-                    _VERDICT_CACHE.set(_cache_key(verdict.risk, judged_text, hook_stage), verdict)
+            # One batched call for all remaining failures 
+            retry_verdicts = await _query_batch(failed_risks, failed_messages, inference_engine, hook_stage)
+            verdicts_by_name.update(retry_verdicts)
 
-    # Apply name_prefix and return in original risk order
+            failed_by_idx = {
+                idx: risk for idx, risk in failed_by_idx.items() if retry_verdicts[risk.name].label == GuardianScore.FAILED
+            }
+
+        # Cache all terminal verdicts (YES/NO/ERROR after retries)
+        for risk_name, verdict in verdicts_by_name.items():
+            if verdict.label in [GuardianScore.YES, GuardianScore.NO]:
+                _VERDICT_CACHE.set(_cache_key(risk_name, judged_text, hook_stage), verdict)
+
     return [
         GuardianVerdict(
             risk=f"{name_prefix}{verdicts_by_name[r.name].risk}",

--- a/src/mellea_skills_compiler/plugins/guardian.py
+++ b/src/mellea_skills_compiler/plugins/guardian.py
@@ -465,13 +465,13 @@ class GuardianAuditPlugin(
     async def check_input(self, payload: Any, ctx: Any) -> None:
         """Pre-generation: assess input prompt for risks (observe-only)."""
         verdicts = await _run_guardian_pre_checks(self, payload, self.risks, self.inference_engine)
-        self.all_verdicts.extend(verdicts)
+        self._record_verdicts(verdicts, getattr(payload, "generation_id", None))
 
     @hook(HookType.GENERATION_POST_CALL, mode=PluginMode.AUDIT)
     async def check_output(self, payload: Any, ctx: Any) -> None:
         """Post-generation: assess LLM output for risks (observe-only)."""
         verdicts = await _run_guardian_post_checks(self, payload, self.risks, self.inference_engine)
-        self.all_verdicts.extend(verdicts)
+        self._record_verdicts(verdicts, getattr(payload, "generation_id", None))
 
     @hook(HookType.TOOL_PRE_INVOKE, mode=PluginMode.AUDIT)
     async def check_tool_input(self, payload: Any, ctx: Any) -> None:
@@ -653,7 +653,7 @@ class GuardianEnforcePlugin(
     async def enforce_output(self, payload: Any, ctx: Any) -> Any:
         """Post-generation: block if LLM output has risks."""
         verdicts = await _run_guardian_post_checks(self, payload, self.risks, self.inference_engine)
-        self.all_verdicts.extend(verdicts)
+        self._record_verdicts(verdicts, getattr(payload, "generation_id", None))
 
         flagged = [v.risk for v in verdicts if v.label == GuardianScore.YES]
         failed = [

--- a/src/mellea_skills_compiler/plugins/guardian.py
+++ b/src/mellea_skills_compiler/plugins/guardian.py
@@ -23,10 +23,8 @@ Usage (enforce mode — blocks on risk):
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import threading
-from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
 from mellea.core.requirement import Requirement
@@ -44,6 +42,7 @@ from mellea_skills_compiler.enums import (
 )
 from mellea_skills_compiler.models import GuardianVerdict, NexusRisk
 from mellea_skills_compiler.plugins import BasePlugin
+from mellea_skills_compiler.toolkit.cache_strategy import LRUCache, hash_key
 from mellea_skills_compiler.toolkit.logging import configure_logger
 
 
@@ -54,8 +53,7 @@ GUARDIAN_MAX_CONCURRENCY = 4
 GUARDIAN_CACHE_MAXSIZE = 512
 
 _GUARDIAN_SEMAPHORE = threading.Semaphore(GUARDIAN_MAX_CONCURRENCY)
-_VERDICT_CACHE: OrderedDict[tuple, GuardianVerdict] = OrderedDict()
-_CACHE_LOCK = threading.Lock()
+_VERDICT_CACHE = LRUCache(maxsize=GUARDIAN_CACHE_MAXSIZE)
 
 
 def _blocking_chat(inference_engine, messages_batch):
@@ -64,25 +62,8 @@ def _blocking_chat(inference_engine, messages_batch):
 
 
 def _cache_key(risk_name: str, judged_text: str, stage: HookStage) -> tuple:
-    digest = hashlib.sha256(judged_text.encode("utf-8")).hexdigest()
+    digest = hash_key(judged_text)
     return (risk_name, digest, stage)
-
-
-def _cache_get(risk_name: str, judged_text: str, stage: HookStage) -> Optional[GuardianVerdict]:
-    key = _cache_key(risk_name, judged_text, stage)
-    with _CACHE_LOCK:
-        return _VERDICT_CACHE.get(key)
-
-
-def _cache_set(risk_name: str, judged_text: str, stage: HookStage, verdict: GuardianVerdict) -> None:
-    key = _cache_key(risk_name, judged_text, stage)
-    with _CACHE_LOCK:
-        if key in _VERDICT_CACHE:
-            _VERDICT_CACHE.move_to_end(key)
-        else:
-            if len(_VERDICT_CACHE) >= GUARDIAN_CACHE_MAXSIZE:
-                _VERDICT_CACHE.popitem(last=False)
-            _VERDICT_CACHE[key] = verdict
 
 
 def _parse_guardian_score(text: str) -> str:
@@ -165,7 +146,7 @@ async def _call_guardian(
     messages_to_query = []
 
     for risk in risks:
-        cached = _cache_get(risk.name, judged_text, hook_stage)
+        cached = _VERDICT_CACHE.get(_cache_key(risk.name, judged_text, hook_stage))
         if cached:
             cached_verdicts[risk.name] = cached
         else:
@@ -213,7 +194,7 @@ async def _call_guardian(
                 )
                 verdicts_by_name[risk.name] = verdict
                 if label in [GuardianScore.YES, GuardianScore.NO]:
-                    _cache_set(risk.name, judged_text, hook_stage, verdict)
+                    _VERDICT_CACHE.set(_cache_key(risk.name, judged_text, hook_stage), verdict)
 
         # Concurrent retries for failed predictions
         if failed_indices:
@@ -237,7 +218,7 @@ async def _call_guardian(
             for verdict in latest_by_idx.values():
                 verdicts_by_name[verdict.risk] = verdict
                 if verdict.label in [GuardianScore.YES, GuardianScore.NO]:
-                    _cache_set(verdict.risk, judged_text, hook_stage, verdict)
+                    _VERDICT_CACHE.set(_cache_key(verdict.risk, judged_text, hook_stage), verdict)
 
     # Apply name_prefix and return in original risk order
     return [

--- a/src/mellea_skills_compiler/toolkit/cache_strategy.py
+++ b/src/mellea_skills_compiler/toolkit/cache_strategy.py
@@ -1,0 +1,53 @@
+"""LRU caching strategy for reusable hooks and services."""
+
+import hashlib
+import threading
+from collections import OrderedDict
+from typing import Any, Optional
+
+
+def hash_key(*parts: str) -> str:
+    """Compute SHA256 hash of concatenated string parts for use in cache keys."""
+    content = "".join(parts).encode("utf-8")
+    return hashlib.sha256(content).hexdigest()
+
+
+class LRUCache:
+    """Thread-safe LRU cache with configurable maximum size.
+
+    When the cache reaches `maxsize`, the least-recently-used (oldest) entry
+    is evicted on the next insertion. Accessing an existing key promotes it
+    to the end (most recently used).
+    """
+
+    def __init__(self, maxsize: int = 512):
+        """Initialize LRU cache.
+
+        Args:
+            maxsize: Maximum number of entries before eviction begins.
+        """
+        self.maxsize = maxsize
+        self._cache: OrderedDict[Any, Any] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: Any) -> Optional[Any]:
+        """Get a value from the cache by key.
+
+        Returns None if not found.
+        """
+        with self._lock:
+            return self._cache.get(key)
+
+    def set(self, key: Any, value: Any) -> None:
+        """Set a key-value pair in the cache.
+
+        If the key already exists, it is moved to the end (marked most recently used).
+        If the cache is at capacity, the least recently used (oldest) entry is removed.
+        """
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+            else:
+                if len(self._cache) >= self.maxsize:
+                    self._cache.popitem(last=False)
+            self._cache[key] = value

--- a/src/mellea_skills_compiler/toolkit/profiling.py
+++ b/src/mellea_skills_compiler/toolkit/profiling.py
@@ -1,42 +1,78 @@
 """Performance profiling utilities."""
 
-import cProfile
 import functools
 import os
-import pstats
-from io import StringIO
 from typing import Callable, TypeVar
 
 F = TypeVar("F", bound=Callable)
 
 
+def _is_profiling_enabled() -> bool:
+    """Check if MELLEA_PROFILE env var enables profiling.
+
+    Accepts 1, true, yes, on (case-insensitive). Any other value disables it.
+    """
+    val = os.environ.get("MELLEA_PROFILE", "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
 def profile_if_enabled(func: F) -> F:
     """Wrap a function to profile it if MELLEA_PROFILE env var is set.
 
-    Set MELLEA_PROFILE=1 to enable cProfile profiling of the command.
-    Profiling results (top 40 functions by cumulative time) are printed
-    to stdout after the command completes.
+    Uses yappi to profile all threads (main, fixture workers, asyncio.to_thread
+    workers, etc.), capturing time from ThreadPoolExecutor fan-out in certify
+    and Guardian's asyncio.to_thread LLM calls that cProfile would miss.
+
+    Set MELLEA_PROFILE=1 to enable profiling of the command.
+    Profiling results include per-thread summaries and top 40 functions by
+    total time, printed to stdout after the command completes.
+
+    Requires yappi: install via `pip install -e '.[profile]'`
 
     Example:
-        MELLEA_PROFILE=1 mellea-skills-compiler compile spec.yaml
+        MELLEA_PROFILE=1 mellea-skills compile spec.yaml
+        MELLEA_PROFILE=1 mellea-skills certify <pipeline_dir> -n 3
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        if not os.environ.get("MELLEA_PROFILE"):
+        if not _is_profiling_enabled():
             return func(*args, **kwargs)
 
-        pr = cProfile.Profile()
-        pr.enable()
+        try:
+            import yappi
+        except ImportError:
+            raise RuntimeError(
+                "Profiling requires yappi. Install it with:\n"
+                "  pip install -e '.[profile]'"
+            ) from None
+
+        yappi.set_clock_type("WALL")
+        yappi.start()
         try:
             result = func(*args, **kwargs)
         finally:
-            pr.disable()
-            stream = StringIO()
-            stats = pstats.Stats(pr, stream=stream).sort_stats("cumulative")
-            stats.print_stats(40)
+            yappi.stop()
             print("\n" + "=" * 80)
             print("PROFILING RESULTS (MELLEA_PROFILE=1)")
             print("=" * 80)
-            print(stream.getvalue())
+
+            thread_stats = yappi.get_thread_stats()
+            print("\nPer-thread summary:")
+            for stat in thread_stats:
+                print(
+                    f"  Thread {stat.id:5d} ({stat.name:20s}): {stat.ttot:10.3f}s"
+                )
+
+            print("\nTop 40 functions by total time:")
+            func_stats = yappi.get_func_stats()
+            func_stats.sort("ttot", sort_order="desc")
+
+            for idx, stat in enumerate(func_stats[:40], 1):
+                module_name = stat.module
+                func_name = stat.name
+                ttot = stat.ttot
+                print(f"  {idx:2d}. {module_name}:{func_name:40s} {ttot:10.3f}s")
+
+            yappi.clear_stats()
         return result
     return wrapper

--- a/src/mellea_skills_compiler/toolkit/profiling.py
+++ b/src/mellea_skills_compiler/toolkit/profiling.py
@@ -1,0 +1,42 @@
+"""Performance profiling utilities."""
+
+import cProfile
+import functools
+import os
+import pstats
+from io import StringIO
+from typing import Callable, TypeVar
+
+F = TypeVar("F", bound=Callable)
+
+
+def profile_if_enabled(func: F) -> F:
+    """Wrap a function to profile it if MELLEA_PROFILE env var is set.
+
+    Set MELLEA_PROFILE=1 to enable cProfile profiling of the command.
+    Profiling results (top 40 functions by cumulative time) are printed
+    to stdout after the command completes.
+
+    Example:
+        MELLEA_PROFILE=1 mellea-skills-compiler compile spec.yaml
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if not os.environ.get("MELLEA_PROFILE"):
+            return func(*args, **kwargs)
+
+        pr = cProfile.Profile()
+        pr.enable()
+        try:
+            result = func(*args, **kwargs)
+        finally:
+            pr.disable()
+            stream = StringIO()
+            stats = pstats.Stats(pr, stream=stream).sort_stats("cumulative")
+            stats.print_stats(40)
+            print("\n" + "=" * 80)
+            print("PROFILING RESULTS (MELLEA_PROFILE=1)")
+            print("=" * 80)
+            print(stream.getvalue())
+        return result
+    return wrapper

--- a/tests/mellea_skills_compiler/plugins/test_audit.py
+++ b/tests/mellea_skills_compiler/plugins/test_audit.py
@@ -179,16 +179,19 @@ class TestAuditTrailHooks:
         from mellea_skills_compiler.models import GuardianVerdict
 
         # Add verdicts to guardian plugin
-        audit_plugin.guardian_plugin.all_verdicts = [
+        verdicts = [
             GuardianVerdict(risk="jailbreak", label="No", raw_output="<score>no</score>", hook_stage=HookStage.POST),
             GuardianVerdict(risk="harm", label="No", raw_output="<score>no</score>", hook_stage=HookStage.POST),
         ]
+        generation_id = "gen-test-1"
+        audit_plugin.guardian_plugin._record_verdicts(verdicts, generation_id=generation_id)
 
         payload = MagicMock()
         payload.model_output = MagicMock(value="Test output")
         payload.latency_ms = 150
         payload.session_id = "session-1"
         payload.request_id = "req-1"
+        payload.generation_id = generation_id
 
         ctx = MagicMock()
 
@@ -207,16 +210,19 @@ class TestAuditTrailHooks:
         from mellea_skills_compiler.models import GuardianVerdict
 
         # Add verdicts to guardian plugin with one risk detected
-        audit_plugin.guardian_plugin.all_verdicts = [
+        verdicts = [
             GuardianVerdict(risk="jailbreak", label="Yes", raw_output="<score>yes</score>", hook_stage=HookStage.POST),
             GuardianVerdict(risk="harm", label="No", raw_output="<score>no</score>", hook_stage=HookStage.POST),
         ]
+        generation_id = "gen-test-2"
+        audit_plugin.guardian_plugin._record_verdicts(verdicts, generation_id=generation_id)
 
         payload = MagicMock()
         payload.model_output = MagicMock(value="Test output")
         payload.latency_ms = 200
         payload.session_id = "session-1"
         payload.request_id = "req-1"
+        payload.generation_id = generation_id
 
         ctx = MagicMock()
 
@@ -393,9 +399,11 @@ class TestAuditTrailSummary:
         from mellea_skills_compiler.models import GuardianVerdict
 
         # Add verdict with risk detected to guardian plugin
-        audit_plugin.guardian_plugin.all_verdicts = [
+        verdicts = [
             GuardianVerdict(risk="test", label="Yes", raw_output="<score>yes</score>", hook_stage=HookStage.POST),
         ]
+        generation_id = "gen-test-3"
+        audit_plugin.guardian_plugin._record_verdicts(verdicts, generation_id=generation_id)
 
         # Add generation with risk
         payload = MagicMock()
@@ -403,6 +411,7 @@ class TestAuditTrailSummary:
         payload.latency_ms = 100
         payload.session_id = "s1"
         payload.request_id = "r1"
+        payload.generation_id = generation_id
 
         asyncio.run(audit_plugin.log_post_call(payload, MagicMock()))
 

--- a/tests/mellea_skills_compiler/plugins/test_audit_id_correlation.py
+++ b/tests/mellea_skills_compiler/plugins/test_audit_id_correlation.py
@@ -81,3 +81,21 @@ def test_id_map_and_positional_lookup_return_distinguishable_results(audit_setup
         "positional-fallback should return the last-recorded verdict; if this "
         "test fails, the fallback stopped being distinguishable from the id-map"
     )
+
+
+def test_lookup_returns_empty_not_positional_when_id_present_but_unpopulated(audit_setup, caplog):
+    """generation_id present but never recorded — must return [], never the
+    positional tail (which would misattribute an unrelated generation's verdict).
+    """
+    guardian_plugin, audit_plugin = audit_setup
+    v_other = GuardianVerdict(risk="harm", label=GuardianScore.YES, raw_output="other", hook_stage=HookStage.POST)
+    guardian_plugin._record_verdicts([v_other], generation_id="gen-other")
+
+    with caplog.at_level("WARNING"):
+        result = audit_plugin._lookup_verdicts_by_generation_id("gen-missing")
+
+    assert result == [], (
+        "present-but-unpopulated generation_id must return [], not silently "
+        "fall back to the positional tail and misattribute gen-other's verdict"
+    )
+    assert any("gen-missing" in r.message for r in caplog.records)

--- a/tests/mellea_skills_compiler/plugins/test_guardian_0_7.py
+++ b/tests/mellea_skills_compiler/plugins/test_guardian_0_7.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -136,6 +136,44 @@ class TestRecordVerdictsIndexing:
         audit_plugin._record_verdicts([v], generation_id=None)
         assert v in audit_plugin.all_verdicts
         assert audit_plugin.verdicts_by_generation_id == {}
+
+
+class TestObserveOnlyHooksIndexByGenerationId:
+    """Regression for the 3-site bug: check_input/check_output/enforce_output
+    must route through _record_verdicts, not a raw unlocked .extend()."""
+
+    @pytest.mark.asyncio
+    async def test_check_input_indexes_verdicts_by_generation_id(self, audit_plugin):
+        from mellea_skills_compiler.plugins import guardian as gmod
+
+        v = GuardianVerdict(risk="harm", label=GuardianScore.YES, raw_output="in", hook_stage=HookStage.PRE)
+        payload = SimpleNamespace(generation_id="gen-ci")
+        with patch.object(gmod, "_run_guardian_pre_checks", new=AsyncMock(return_value=[v])):
+            await audit_plugin.check_input(payload, ctx=None)
+        assert v in audit_plugin.all_verdicts
+        assert audit_plugin.verdicts_by_generation_id.get("gen-ci") == [v]
+
+    @pytest.mark.asyncio
+    async def test_check_output_indexes_verdicts_by_generation_id(self, audit_plugin):
+        from mellea_skills_compiler.plugins import guardian as gmod
+
+        v = GuardianVerdict(risk="harm", label=GuardianScore.YES, raw_output="out", hook_stage=HookStage.POST)
+        payload = SimpleNamespace(generation_id="gen-co")
+        with patch.object(gmod, "_run_guardian_post_checks", new=AsyncMock(return_value=[v])):
+            await audit_plugin.check_output(payload, ctx=None)
+        assert v in audit_plugin.all_verdicts
+        assert audit_plugin.verdicts_by_generation_id.get("gen-co") == [v]
+
+    @pytest.mark.asyncio
+    async def test_enforce_output_indexes_verdicts_by_generation_id(self, enforce_plugin):
+        from mellea_skills_compiler.plugins import guardian as gmod
+
+        v = GuardianVerdict(risk="harm", label=GuardianScore.NO, raw_output="out", hook_stage=HookStage.POST)
+        payload = SimpleNamespace(generation_id="gen-eo")
+        with patch.object(gmod, "_run_guardian_post_checks", new=AsyncMock(return_value=[v])):
+            await enforce_plugin.enforce_output(payload, ctx=None)
+        assert v in enforce_plugin.all_verdicts
+        assert enforce_plugin.verdicts_by_generation_id.get("gen-eo") == [v]
 
 
 class TestConcurrency:

--- a/tests/mellea_skills_compiler/plugins/test_guardian_0_7.py
+++ b/tests/mellea_skills_compiler/plugins/test_guardian_0_7.py
@@ -69,7 +69,8 @@ class TestThunkActionAccess:
 class TestIdCorrelation:
     """Requirement-driven generations are skipped via generation_id, not private attrs."""
 
-    def test_pre_call_records_requirement_generation_id(self, audit_plugin):
+    @pytest.mark.asyncio
+    async def test_pre_call_records_requirement_generation_id(self, audit_plugin):
         from mellea.core.requirement import Requirement
 
         req = Requirement(description="must be nice")
@@ -79,12 +80,13 @@ class TestIdCorrelation:
         )
         from mellea_skills_compiler.plugins import guardian as gmod
 
-        gmod._run_guardian_pre_checks(
+        await gmod._run_guardian_pre_checks(
             audit_plugin, payload, audit_plugin.risks, "ollama"
         )
         assert "gen-abc" in audit_plugin._requirement_generation_ids
 
-    def test_post_call_skips_recorded_id_without_reading_action(self, audit_plugin):
+    @pytest.mark.asyncio
+    async def test_post_call_skips_recorded_id_without_reading_action(self, audit_plugin):
         from mellea_skills_compiler.plugins import guardian as gmod
 
         audit_plugin._requirement_generation_ids.add("gen-xyz")
@@ -97,13 +99,14 @@ class TestIdCorrelation:
             generation_id="gen-xyz",
             prompt="what?",
         )
-        result = gmod._run_guardian_post_checks(
+        result = await gmod._run_guardian_post_checks(
             audit_plugin, payload, audit_plugin.risks, "ollama"
         )
         assert result == []
         assert "gen-xyz" not in audit_plugin._requirement_generation_ids
 
-    def test_post_call_falls_back_to_action_check_when_id_absent(self, audit_plugin):
+    @pytest.mark.asyncio
+    async def test_post_call_falls_back_to_action_check_when_id_absent(self, audit_plugin):
         """Belt-and-braces: pre-0.7 payloads with no generation_id still skip Requirements."""
         from mellea.core.requirement import Requirement
         from mellea_skills_compiler.plugins import guardian as gmod
@@ -113,7 +116,7 @@ class TestIdCorrelation:
         payload = SimpleNamespace(
             model_output=model_output, generation_id=None, prompt=""
         )
-        result = gmod._run_guardian_post_checks(
+        result = await gmod._run_guardian_post_checks(
             audit_plugin, payload, audit_plugin.risks, "ollama"
         )
         assert result == []

--- a/tests/mellea_skills_compiler/toolkit/test_cache_strategy.py
+++ b/tests/mellea_skills_compiler/toolkit/test_cache_strategy.py
@@ -1,0 +1,114 @@
+"""Unit tests for the LRU cache strategy."""
+
+import threading
+
+import pytest
+
+from mellea_skills_compiler.toolkit.cache_strategy import LRUCache, hash_key
+
+
+class TestHashKey:
+    """Tests for the hash_key utility function."""
+
+    def test_hash_key_consistent(self):
+        """Same input always produces same hash."""
+        key1 = hash_key("test_string")
+        key2 = hash_key("test_string")
+        assert key1 == key2
+
+    def test_hash_key_different(self):
+        """Different inputs produce different hashes."""
+        key1 = hash_key("string1")
+        key2 = hash_key("string2")
+        assert key1 != key2
+
+    def test_hash_key_multiple_parts(self):
+        """Multiple parts are concatenated and hashed."""
+        key1 = hash_key("part1", "part2")
+        key2 = hash_key("part1part2")
+        assert key1 == key2
+
+    def test_hash_key_empty(self):
+        """Empty input produces a valid hash."""
+        key = hash_key("")
+        assert isinstance(key, str)
+        assert len(key) == 64  # SHA256 hex digest is 64 chars
+
+
+class TestLRUCache:
+    """Tests for the LRUCache class."""
+
+    def test_get_set_basic(self):
+        """Basic get/set operations work."""
+        cache = LRUCache(maxsize=2)
+        cache.set("key1", "value1")
+        assert cache.get("key1") == "value1"
+
+    def test_get_missing_returns_none(self):
+        """Getting a missing key returns None."""
+        cache = LRUCache(maxsize=2)
+        assert cache.get("missing") is None
+
+    def test_eviction_on_overflow(self):
+        """Oldest entry is evicted when maxsize is reached."""
+        cache = LRUCache(maxsize=2)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.set("key3", "value3")  # Should evict key1
+        assert cache.get("key1") is None
+        assert cache.get("key2") == "value2"
+        assert cache.get("key3") == "value3"
+
+    def test_get_does_not_promote(self):
+        """Reading a key does not promote it (no move-to-end on get)."""
+        cache = LRUCache(maxsize=2)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        _ = cache.get("key1")  # Read doesn't promote
+        cache.set("key3", "value3")  # Should evict key1 (oldest by insertion order)
+        assert cache.get("key1") is None  # key1 was evicted
+        assert cache.get("key2") == "value2"
+        assert cache.get("key3") == "value3"
+
+    def test_lru_promotion_on_set(self):
+        """Re-setting an existing key promotes it to most recently used."""
+        cache = LRUCache(maxsize=2)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.set("key1", "updated1")  # Promote key1
+        cache.set("key3", "value3")  # Should evict key2, not key1
+        assert cache.get("key1") == "updated1"
+        assert cache.get("key2") is None
+        assert cache.get("key3") == "value3"
+
+    def test_thread_safety_concurrent_sets(self):
+        """Concurrent sets don't corrupt cache state."""
+        cache = LRUCache(maxsize=100)
+        errors = []
+
+        def worker(offset: int):
+            try:
+                for i in range(50):
+                    key = f"key_{offset}_{i}"
+                    cache.set(key, f"value_{offset}_{i}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Errors during concurrent sets: {errors}"
+        # All 500 keys should be present (or evicted if maxsize was smaller)
+        assert len(cache._cache) <= cache.maxsize
+
+    def test_maxsize_one(self):
+        """Cache with maxsize=1 evicts on every new insertion."""
+        cache = LRUCache(maxsize=1)
+        cache.set("key1", "value1")
+        assert cache.get("key1") == "value1"
+        cache.set("key2", "value2")
+        assert cache.get("key1") is None
+        assert cache.get("key2") == "value2"


### PR DESCRIPTION
## Summary
This PR has code to:
- integrate the updated AI Atlas Nexus risk format,
- add async/cached Guardian verdicts with concurrent retries, 
- adds CLI profiling support.

### Changes
-  The `generate_policy_manifest()`  risk list  integration handles the new format  of `per_usecase` list

### Guardian Risk Evaluation (async with caching & concurrent retries)
- Convert `_call_guardian()` to async with concurrent retry support for failed predictions
- Add LRU verdict cache to reduce redundant Guardian LLM calls on repeated input
- concurrent batch retries: failed risks are retried in parallel, with accumulating verdicts
- Caches only  the definitive verdicts (YES/NO); failures are not cached, to allow retries
- Replace `deepcopy` workaround with `name_prefix` parameter

#### CLI Profiling & Documentation
- Add `@_profile_if_enabled` decorator for performance profiling via `MELLEA_PROFILE=1` environment variable
- Decorator outputs top 40 functions by cumulative time to stdout
- Applied  to `compile`, `run`, and `certify` commands
- You can test it like this: ` MELLEA_PROFILE=1 mellea-skills certify <filepath>/mellea-skills-compiler/examples/weather/weather_mellea -n 3 --guardian-model ibm/granite3.3-guardian:8b

### Testing
- All 64 existing tests pass (policy manifest, Guardian export templates, audit export)
